### PR TITLE
TEIIDTOOLS-283

### DIFF
--- a/komodo-core/src/main/resources/org/komodo/core/repository/local-repository-config.json
+++ b/komodo-core/src/main/resources/org/komodo/core/repository/local-repository-config.json
@@ -20,15 +20,15 @@
             "type" : "db",
             "connectionUrl": "${komodo.connectionUrl}",
             "driver" : "${komodo.connectionDriver}",
-            "username" : "komodo",
-            "password" : "komodo"
+            "username" : "${komodo.user}",
+            "password" : "${komodo.password}"
         },
         "binaryStorage" : {
           "type"  : "database",
           "driverClass" : "${komodo.connectionDriver}",
           "url" : "${komodo.binaryStoreUrl}",
-          "username" : "komodo",
-          "password" : "komodo"
+          "username" : "${komodo.user}",
+          "password" : "${komodo.password}"
         },
         "transactionManagerLookup" : {
             "name" : "org.komodo.core.internal.repository.KTransactionManagerLookup" 

--- a/komodo-core/src/test/java/org/komodo/core/AbstractLoggingTest.java
+++ b/komodo-core/src/test/java/org/komodo/core/AbstractLoggingTest.java
@@ -22,9 +22,13 @@
 package org.komodo.core;
 
 import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileAttribute;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.komodo.spi.constants.StringConstants;
@@ -73,8 +77,14 @@ public abstract class AbstractLoggingTest implements StringConstants {
     @BeforeClass
     public static void initLogging() throws Exception {
         // create data directory for engine logging
-        _dataDirectory = Files.createTempDirectory( "KomodoEngineDataDir" );
-        System.setProperty( SystemConstants.ENGINE_DATA_DIR, _dataDirectory.toString() );
+        _dataDirectory = Paths.get("target/KomodoEngineDataDir");    	
+    	File f = new File (_dataDirectory.toAbsolutePath().toString());
+    	if (f.exists()) {
+    		f.delete();
+    	} else {
+    		Files.createDirectory(_dataDirectory, new FileAttribute[0]);    		
+    	}
+        System.setProperty(SystemConstants.ENGINE_DATA_DIR,  _dataDirectory.toAbsolutePath().toString());        
 
         // Initialises logging and reduces modeshape logging from DEBUG to INFO
         configureLogPath(KLog.getLogger());

--- a/komodo-core/src/test/java/org/komodo/core/internal/TestObjectOperations.java
+++ b/komodo-core/src/test/java/org/komodo/core/internal/TestObjectOperations.java
@@ -28,9 +28,12 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileAttribute;
 import java.util.Iterator;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -81,8 +84,14 @@ public class TestObjectOperations implements StringConstants {
 
     @BeforeClass
     public static void oneTimeSetup() throws Exception {
-        _dataDirectory = Files.createTempDirectory( "KomodoEngineDataDir" );
-        System.setProperty( SystemConstants.ENGINE_DATA_DIR, _dataDirectory.toString() );
+        _dataDirectory = Paths.get("target/KomodoEngineDataDir");    	
+    	File f = new File (_dataDirectory.toAbsolutePath().toString());
+    	if (f.exists()) {
+    		f.delete();
+    	} else {
+    		Files.createDirectory(_dataDirectory, new FileAttribute[0]);    		
+    	}
+        System.setProperty(SystemConstants.ENGINE_DATA_DIR,  _dataDirectory.toAbsolutePath().toString()); 
     }
 
     @AfterClass

--- a/komodo-core/src/test/java/org/komodo/core/repository/TestLocalRepositoryPersistence.java
+++ b/komodo-core/src/test/java/org/komodo/core/repository/TestLocalRepositoryPersistence.java
@@ -30,17 +30,23 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileAttribute;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
@@ -82,37 +88,38 @@ public class TestLocalRepositoryPersistence extends AbstractLoggingTest implemen
 
     private Connection connection = null;
 
-    private String komodoTestDir() {
-        System.setProperty(ENGINE_DATA_DIR, System.getProperty(JAVA_IO_TMPDIR) + File.separator + "TestLocalRepositoryPersistence");
+    private String komodoTestDir() throws IOException{
+    	Path dir = Paths.get("target/TestLocalRepositoryPersistence");    	
+    	File f = new File (dir.toAbsolutePath().toString());
+    	if (f.exists()) {
+    		f.delete();
+    	} else {
+    		Files.createDirectory(dir, new FileAttribute[0]);    		
+    	}
+        System.setProperty(ENGINE_DATA_DIR,  dir.toAbsolutePath().toString());
         return System.getProperty(ENGINE_DATA_DIR);
     }
 
-    private String komodoPersistenceHost() {
-        System.setProperty(REPOSITORY_PERSISTENCE_HOST, "localhost");
-        return System.getProperty(REPOSITORY_PERSISTENCE_HOST);
-    }
-
     private String komodoConnectionUrl(PersistenceType persistenceType) {
-        System.setProperty(SystemConstants.REPOSITORY_CONNECTION_URL, persistenceType.getConnUrl());
-        return System.getProperty(SystemConstants.REPOSITORY_CONNECTION_URL);
+        System.setProperty(SystemConstants.REPOSITORY_PERSISTENCE_CONNECTION_URL, persistenceType.getConnUrl());
+        return System.getProperty(SystemConstants.REPOSITORY_PERSISTENCE_CONNECTION_URL);
     }
 
     private String komodoBinaryUrl(PersistenceType persistenceType) {
-        System.setProperty(SystemConstants.REPOSITORY_BINARY_STORE_URL, persistenceType.getBinaryStoreUrl());
-        return System.getProperty(SystemConstants.REPOSITORY_BINARY_STORE_URL);
+        System.setProperty(SystemConstants.REPOSITORY_PERSISTENCE_BINARY_STORE_URL, persistenceType.getBinaryStoreUrl());
+        return System.getProperty(SystemConstants.REPOSITORY_PERSISTENCE_BINARY_STORE_URL);
     }
 
     private String komodoConnectionDriver(PersistenceType persistenceType) {
-        System.setProperty(SystemConstants.REPOSITORY_CONNECTION_DRIVER, persistenceType.getDriver());
-        return System.getProperty(SystemConstants.REPOSITORY_CONNECTION_DRIVER);
+        System.setProperty(SystemConstants.REPOSITORY_PERSISTENCE_CONNECTION_DRIVER, persistenceType.getDriver());
+        return System.getProperty(SystemConstants.REPOSITORY_PERSISTENCE_CONNECTION_DRIVER);
     }
 
-    private void setKomodoDataDir(PersistenceType persistenceType) {
-        komodoTestDir();
-        komodoPersistenceHost();
-        komodoConnectionUrl(persistenceType);
-        komodoBinaryUrl(persistenceType);
-        komodoConnectionDriver(persistenceType);
+    private void setKomodoDataDir(PersistenceType persistenceType) throws Exception {
+    	komodoTestDir();
+    	komodoConnectionUrl(persistenceType);
+    	komodoBinaryUrl(persistenceType);
+    	komodoConnectionDriver(persistenceType);    	
         PRODUCTION_REPOSITORY_DB = komodoTestDir() + File.separator + "komododb";
     }
 
@@ -220,16 +227,14 @@ public class TestLocalRepositoryPersistence extends AbstractLoggingTest implemen
         connection = null;
     }
 
-    private Connection postgresDBConnection() {
+    private Connection postgresDBConnection(PersistenceType type) {
         Connection connection = null;
         //
         // Check we have a postgres db handy. If not then skip this test
         //
         try {
-            Class.forName(PersistenceType.PGSQL.getDriver());
-            connection = DriverManager.getConnection(PersistenceType.PGSQL.getConnUrl(),
-                                                                    REPOSITORY_PERSISTENCE_USERNAME,
-                                                                    REPOSITORY_PERSISTENCE_PASSWORD);
+            Class.forName(type.getDriver());
+            connection = DriverManager.getConnection(type.getConnUrl(), type.getUser(), type.getPassword());
         } catch (Exception ex) {
             // Nothing to do
         }
@@ -347,7 +352,7 @@ public class TestLocalRepositoryPersistence extends AbstractLoggingTest implemen
 
     @Test
     public void testProductionRepositoryPersistenceWorkspacePSQL() throws Exception {
-        connection  = postgresDBConnection();
+        connection  = postgresDBConnection(PersistenceType.PGSQL);
         Assume.assumeNotNull(connection);
 
         setKomodoDataDir(PersistenceType.PGSQL);
@@ -428,7 +433,7 @@ public class TestLocalRepositoryPersistence extends AbstractLoggingTest implemen
 
     @Test
     public void testProductionRepositoryPersistenceObjectsPSQL() throws Exception {
-        connection = postgresDBConnection();
+        connection = postgresDBConnection(PersistenceType.PGSQL);
         Assume.assumeNotNull(connection);
 
         setKomodoDataDir(PersistenceType.PGSQL);
@@ -541,7 +546,7 @@ public class TestLocalRepositoryPersistence extends AbstractLoggingTest implemen
 
     @Test
     public void testBinaryValuePersistencePSQL() throws Exception {
-        connection = postgresDBConnection();
+        connection = postgresDBConnection(PersistenceType.PGSQL);
         Assume.assumeNotNull(connection);
 
         setKomodoDataDir(PersistenceType.PGSQL);

--- a/komodo-metadata-instance/pom.xml
+++ b/komodo-metadata-instance/pom.xml
@@ -24,12 +24,12 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.jboss.teiid</groupId>
+			<groupId>org.teiid</groupId>
 			<artifactId>teiid-engine</artifactId>
 		</dependency>
 
 		<dependency>
-			<groupId>org.jboss.teiid</groupId>
+			<groupId>org.teiid</groupId>
 			<artifactId>teiid-admin</artifactId>
 		</dependency>
 

--- a/komodo-metadata-instance/src/main/java/org/komodo/metadata/DefaultMetadataInstance.java
+++ b/komodo-metadata-instance/src/main/java/org/komodo/metadata/DefaultMetadataInstance.java
@@ -122,7 +122,7 @@ public class DefaultMetadataInstance implements MetadataInstance {
         this.connectionProvider = connectionProvider;
     }
 
-    private Admin admin() throws AdminException {
+    protected Admin admin() throws AdminException {
     	return connectionProvider.getAdmin();
     }
     
@@ -133,7 +133,7 @@ public class DefaultMetadataInstance implements MetadataInstance {
      *        the error being handled (cannot be <code>null</code>)
      * @return the error (never <code>null</code>)
      */
-    private static KException handleError(Throwable e) {
+    protected static KException handleError(Throwable e) {
         assert (e != null);
     
         if (e instanceof KException) {
@@ -143,7 +143,7 @@ public class DefaultMetadataInstance implements MetadataInstance {
         return new KException(e);
     }
 
-    private void checkStarted() throws KException {
+    protected void checkStarted() throws KException {
         if (getCondition() != Condition.REACHABLE) {
         	String msg = Messages.getString(Messages.MetadataServer.serverCanNotBeReached);
 	        throw new KException(msg);

--- a/komodo-openshift/scripts/komodo-teiid-wildfly-swarm-s2i.json
+++ b/komodo-openshift/scripts/komodo-teiid-wildfly-swarm-s2i.json
@@ -492,7 +492,7 @@
                                     },
                                     {
                                     	"name": "SWARM_JAR_ARGS",
-                                    	"value": "-DREPOSITORY_PERSISTENCE_HOST=vdb-builder-persistence"
+                                    	"value": "-DREPOSITORY_PERSISTENCE_HOST=vdb-builder-persistence -DDEV_MODE=true"
                                     },
                                     {
                                         "name": "TEIID_USERNAME",

--- a/komodo-parent/pom.xml
+++ b/komodo-parent/pom.xml
@@ -131,7 +131,7 @@
 		<!-- dependencies from IP-BOM -->
 				
 		<version.commons.io>2.5</version.commons.io>
-		<version.org.teiid>9.3.2</version.org.teiid>
+		<version.org.teiid>10.0.0.Final</version.org.teiid>
 
 		<!-- Instruct the build to use only UTF-8 encoding for source code -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -174,7 +174,9 @@
 		<version.resteasy>3.0.19.Final</version.resteasy>
 		<version.jboss.logging>3.3.0.Final</version.jboss.logging>
 		<version.org.mockito>1.10.19</version.org.mockito>	
-		<version.com.fasterxml.jackson>2.7.4</version.com.fasterxml.jackson>			
+		<version.com.fasterxml.jackson>2.7.4</version.com.fasterxml.jackson>
+        <version.org.osb>1.0.0-SNAPSHOT</version.org.osb>
+        <org.apache.httpcomponents.version>4.5.3</org.apache.httpcomponents.version>			
 	</properties>
 
 	<!-- This section defines the default dependency settings inherited by child 
@@ -339,37 +341,37 @@
 			</dependency>
 
 			<dependency>
-				<groupId>org.jboss.teiid</groupId>
+				<groupId>org.teiid</groupId>
 				<artifactId>teiid-common-core</artifactId>
 				<version>${version.org.teiid}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jboss.teiid</groupId>
+				<groupId>org.teiid</groupId>
 				<artifactId>teiid-api</artifactId>
 				<version>${version.org.teiid}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jboss.teiid</groupId>
+				<groupId>org.teiid</groupId>
 				<artifactId>teiid-engine</artifactId>
 				<version>${version.org.teiid}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jboss.teiid</groupId>
+				<groupId>org.teiid</groupId>
 				<artifactId>teiid-runtime</artifactId>
 				<version>${version.org.teiid}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jboss.teiid</groupId>
+				<groupId>org.teiid</groupId>
 				<artifactId>teiid-admin</artifactId>
 				<version>${version.org.teiid}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jboss.teiid</groupId>
+				<groupId>org.teiid</groupId>
 				<artifactId>teiid-jboss-admin</artifactId>
 				<version>${version.org.teiid}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jboss.teiid</groupId>
+				<groupId>org.teiid</groupId>
 				<artifactId>teiid-client</artifactId>
 				<version>${version.org.teiid}</version>
 			</dependency>
@@ -378,6 +380,17 @@
 				<artifactId>teiid-jdbc</artifactId>
 				<version>${version.wildfly.swarm}</version>
 			</dependency>
+      
+            <dependency>
+              <groupId>org.osb</groupId>
+              <artifactId>kubernetes-service-catalog-client</artifactId>
+              <version>${version.org.osb}</version>        
+            </dependency>   
+            <dependency>
+              <groupId>org.apache.httpcomponents</groupId>
+              <artifactId>httpclient</artifactId>
+              <version>${org.apache.httpcomponents.version}</version>
+            </dependency>                
 
 			<!--Inherited from BOM, but changes the default scope to "test" -->
 			<dependency>

--- a/komodo-spi/src/main/java/org/komodo/spi/constants/SystemConstants.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/constants/SystemConstants.java
@@ -50,36 +50,35 @@ public interface SystemConstants extends StringConstants {
     String REPOSITORY_PERSISTENCE_TYPE = "REPOSITORY_PERSISTENCE_TYPE";
 
     /**
-     * The environment variable that defines the name of the host where the persistence store is located
-     * Cannot use 'komodo.' prefix since Openshift considers this invalid.
-     */
-    String REPOSITORY_PERSISTENCE_HOST = "REPOSITORY_PERSISTENCE_HOST";
-
-    /**
      * The environment variable that defines the connection url of the persistence database.
      * Values should be in the format "jdbc:<type>:<path>"
      */
-    String REPOSITORY_CONNECTION_URL = "komodo.connectionUrl";
+    String REPOSITORY_PERSISTENCE_CONNECTION_URL = "komodo.connectionUrl";
 
     /**
      * The environment variable that defines the connection url to the binary store of
      * the persistence database.
      * Values should be in the format "jdbc:<type>:<path>"
      */
-    String REPOSITORY_BINARY_STORE_URL = "komodo.binaryStoreUrl";
+    String REPOSITORY_PERSISTENCE_BINARY_STORE_URL = "komodo.binaryStoreUrl";
 
     /**
      * The environment variable that defines the driver used for connection to the persistence database
      */
-    String REPOSITORY_CONNECTION_DRIVER = "komodo.connectionDriver";
+    String REPOSITORY_PERSISTENCE_CONNECTION_DRIVER = "komodo.connectionDriver";
 
     /**
      * The repository persistence username
      */
-    String REPOSITORY_PERSISTENCE_USERNAME = "komodo";
+    String REPOSITORY_PERSISTENCE_CONNECTION_USERNAME = "komodo.user";
 
     /**
      * The repository persistence password
      */
-    String REPOSITORY_PERSISTENCE_PASSWORD = "komodo";
+    String REPOSITORY_PERSISTENCE_CONNECTION_PASSWORD = "komodo.password";
+    
+    /**
+     * Set true in Development mode.
+     */
+    String DEV_MODE = "DEV_MODE";    
 }

--- a/komodo-spi/src/main/java/org/komodo/spi/repository/PersistenceType.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/repository/PersistenceType.java
@@ -36,8 +36,8 @@ public enum PersistenceType {
     /**
      * PostgreSQL database used for production
      */
-    PGSQL ("jdbc:postgresql://${REPOSITORY_PERSISTENCE_HOST}/komodo",
-                   "org.postgresql.Driver", true);
+    PGSQL (System.getProperty(SystemConstants.REPOSITORY_PERSISTENCE_CONNECTION_URL),
+    		System.getProperty(SystemConstants.REPOSITORY_PERSISTENCE_CONNECTION_DRIVER), true);
 
     private String connUrl;
 
@@ -72,6 +72,9 @@ public enum PersistenceType {
     }
 
     public String getConnUrl() {
+    	if (connUrl == null && Boolean.getBoolean(SystemConstants.DEV_MODE)) {
+    		return "jdbc:postgresql://localhost/komodo";
+    	}
         return connUrl;
     }
 
@@ -79,12 +82,14 @@ public enum PersistenceType {
      * @return the connection url with any know system properties replaced with their values
      */
     public String getEvaluatedConnUrl() {
-        String url = substitute(connUrl, SystemConstants.ENGINE_DATA_DIR);
-        url = substitute(connUrl, SystemConstants.REPOSITORY_PERSISTENCE_HOST);
+        String url = substitute(getConnUrl(), SystemConstants.ENGINE_DATA_DIR);
         return url;
     }
 
     public String getBinaryStoreUrl() {
+    	if (binaryUrl == null) {
+    		return getConnUrl();
+    	}
         return binaryUrl;
     }
 
@@ -92,15 +97,33 @@ public enum PersistenceType {
      * @return the binary store url with any know system properties replaced with their values
      */
     public String getEvaluatedBinaryStoreUrl() {
-        String url = substitute(binaryUrl, SystemConstants.ENGINE_DATA_DIR);
-        url = substitute(binaryUrl, SystemConstants.REPOSITORY_PERSISTENCE_HOST);
+        String url = substitute(getBinaryStoreUrl(), SystemConstants.ENGINE_DATA_DIR);
         return url;
     }
 
     public String getDriver() {
+    	if (driver == null && Boolean.getBoolean(SystemConstants.DEV_MODE)) {
+    		return "org.postgresql.Driver";
+    	}
         return driver;
     }
+    
+    public String getUser() {
+    	String user = System.getProperty(SystemConstants.REPOSITORY_PERSISTENCE_CONNECTION_USERNAME);
+    	if (user == null && Boolean.getBoolean(SystemConstants.DEV_MODE)) {
+    		return "komodo";
+    	}    	
+    	return user;
+    }
 
+    public String getPassword() {
+    	String password = System.getProperty(SystemConstants.REPOSITORY_PERSISTENCE_CONNECTION_PASSWORD);
+    	if (password == null && Boolean.getBoolean(SystemConstants.DEV_MODE)) {
+    		return "komodo";
+    	}
+    	return password;
+    }
+    
     /**
      * In cases like PGSQL, the data store is externally managed while H2 is internally managed.
      * This flag distinguishes between the two types of store.

--- a/komodo-utils/src/test/java/org/komodo/utils/TestKLog.java
+++ b/komodo-utils/src/test/java/org/komodo/utils/TestKLog.java
@@ -33,6 +33,9 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileAttribute;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -54,8 +57,14 @@ public class TestKLog {
     @BeforeClass
     public static void initDataDirectory() throws Exception {
         // create data directory for engine logging
-        _dataDirectory = Files.createTempDirectory( "KomodoEngineDataDir" );
-        System.setProperty( SystemConstants.ENGINE_DATA_DIR, _dataDirectory.toString() );
+        _dataDirectory = Paths.get("target/KomodoEngineDataDir");    	
+    	File f = new File (_dataDirectory.toAbsolutePath().toString());
+    	if (f.exists()) {
+    		f.delete();
+    	} else {
+    		Files.createDirectory(_dataDirectory, new FileAttribute[0]);    		
+    	}
+        System.setProperty(SystemConstants.ENGINE_DATA_DIR,  _dataDirectory.toAbsolutePath().toString());     	
     }
 
     @AfterClass

--- a/server/komodo-rest/docker/Dockerfile
+++ b/server/komodo-rest/docker/Dockerfile
@@ -1,0 +1,8 @@
+#######################################################################
+# This is from fabric8 plugin uses for WildFly-Swarm                 #
+#######################################################################
+
+FROM registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift
+ENV AB_JOLOKIA_OFF=true AB_OFF=true JAVA_APP_DIR=/deployments
+EXPOSE 8080 8778 9779
+COPY maven /deployments/

--- a/server/komodo-rest/pom.xml
+++ b/server/komodo-rest/pom.xml
@@ -25,7 +25,7 @@
 		<app.rest.version>${project.version}</app.rest.version>
 		<app.rest.description>A tool that allows creating, editing and managing dynamic VDBs and their contents</app.rest.description>
 		<!-- Must remain all on one line. Otherwise, VFSUtils.readManifest complains of invalid header -->
-		<manifest.dependencies>org.jboss.logging,org.jboss.teiid.api,org.jboss.teiid.admin,org.jboss.teiid.common-core,org.jboss.teiid,org.jboss.teiid.client,io.swagger,com.fasterxml.jackson.core.jackson-core,com.fasterxml.jackson.core.jackson-databind,com.fasterxml.jackson.core.jackson-annotations</manifest.dependencies>
+		<manifest.dependencies>org.jboss.logging,org.jboss.teiid.api,org.jboss.teiid.admin,org.jboss.teiid.common-core,org.jboss.teiid,org.jboss.teiid.client,io.swagger,com.fasterxml.jackson.core.jackson-core,com.fasterxml.jackson.core.jackson-databind,com.fasterxml.jackson.core.jackson-annotations,org.jboss.as.cli,org.jboss.as.controller,org.jboss.dmr</manifest.dependencies>
 	</properties>
 
 	<dependencies>
@@ -34,7 +34,7 @@
 			<artifactId>komodo-relational</artifactId>
             <exclusions>
               <exclusion>
-                <groupId>org.jboss.teiid</groupId>
+                <groupId>org.teiid</groupId>
                 <artifactId>*</artifactId>
               </exclusion>
             </exclusions>
@@ -75,37 +75,37 @@
         </dependency>               			
     
 		<dependency>
-			<groupId>org.jboss.teiid</groupId>
+			<groupId>org.teiid</groupId>
 			<artifactId>teiid-api</artifactId>
 			<scope>provided</scope>
 		</dependency> 
 		<dependency>
-			<groupId>org.jboss.teiid</groupId>
+			<groupId>org.teiid</groupId>
 			<artifactId>teiid-client</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jboss.teiid</groupId>
+			<groupId>org.teiid</groupId>
 			<artifactId>teiid-engine</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jboss.teiid</groupId>
+			<groupId>org.teiid</groupId>
 			<artifactId>teiid-common-core</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jboss.teiid</groupId>
+			<groupId>org.teiid</groupId>
 			<artifactId>teiid-admin</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jboss.teiid</groupId>
+			<groupId>org.teiid</groupId>
 			<artifactId>teiid-jboss-admin</artifactId>
 			<scope>provided</scope>
             <exclusions>
               <exclusion>
-                <groupId>org.jboss.teiid</groupId>
+                <groupId>org.teiid</groupId>
                 <artifactId>*</artifactId>
               </exclusion>
             </exclusions>
@@ -127,12 +127,11 @@
 			<artifactId>teiid-jdbc</artifactId>
             <exclusions>
               <exclusion>
-                <groupId>org.jboss.teiid</groupId>
+                <groupId>org.teiid</groupId>
                 <artifactId>*</artifactId>
               </exclusion>
             </exclusions>      
 		</dependency>
-
 	    <dependency>
 	      <groupId>javax</groupId>
 	      <artifactId>javaee-api</artifactId>
@@ -146,9 +145,7 @@
         <dependency>
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpclient</artifactId>
-          <version>4.5.3</version>
         </dependency>   
-	
   		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
@@ -169,6 +166,20 @@
 		    <artifactId>jackson-annotations</artifactId>
 		    <scope>provided</scope>
 		</dependency>	
+        <dependency>
+          <groupId>org.osb</groupId>
+          <artifactId>kubernetes-service-catalog-client</artifactId>
+            <exclusions>
+              <exclusion>
+    			<groupId>com.fasterxml.jackson.core</groupId>
+    			<artifactId>*</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+              </exclusion>
+            </exclusions>                   
+        </dependency>
 
         <!-- Test Dependencies -->
 		<dependency>
@@ -307,6 +318,46 @@
 					</arguments>
 				</configuration>
 			</plugin>
+              <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.23.0</version>
+                <configuration>
+                  <registry>registry.hub.docker.com</registry>
+                  <images>
+                    <image>
+                      <name>teiid/komodo:${project.version}</name>
+                      <alias>komodo</alias>
+                      <build>
+                        <filter>@</filter>
+                        <dockerFileDir>${project.basedir}/docker</dockerFileDir>
+                        <assembly>
+                            <inline>
+                              <fileSets>
+                              <fileSet>
+                                <directory>${project.build.directory}</directory>
+                                <outputDirectory>/</outputDirectory>   
+                                <includes>
+                                  <include>**/*-swarm.jar</include>
+                                </includes>
+                              </fileSet>
+                             </fileSets>                            
+                            </inline>
+                        </assembly>
+                      </build>
+                    </image>                   
+                  </images>
+                </configuration>
+                <executions>
+                  <execution>
+                    <id>docker-build</id>
+                    <goals>
+                      <goal>build</goal>
+                      <goal>push</goal>
+                    </goals>
+                  </execution>
+                </executions>
+              </plugin>      
 		</plugins>
 	</build>
 

--- a/server/komodo-rest/src/main/java/org/komodo/rest/ApplicationProperties.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/ApplicationProperties.java
@@ -21,9 +21,27 @@
  */
 package org.komodo.rest;
 
-public class ApplicationProperties {
+import org.komodo.spi.constants.SystemConstants;
+
+public class ApplicationProperties implements SystemConstants{
 
 	public static String getNamespace() {
 		return System.getProperty("NAMESPACE");
 	}
+
+	public static String getRepositoryPersistenceDriver() {
+		return System.getProperty(REPOSITORY_PERSISTENCE_CONNECTION_DRIVER);
+	}
+	
+	public static String getRepositoryPersistenceURL() {
+		return System.getProperty(REPOSITORY_PERSISTENCE_CONNECTION_URL);
+	}
+	
+	public static String getRepositoryPersistenceUser() {
+		return System.getProperty(REPOSITORY_PERSISTENCE_CONNECTION_USERNAME);
+	}
+	
+	public static String getRepositoryPersistencePassword() {
+		return System.getProperty(REPOSITORY_PERSISTENCE_CONNECTION_PASSWORD);
+	}	
 }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/ApplicationProperties.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/ApplicationProperties.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest;
+
+public class ApplicationProperties {
+
+	public static String getNamespace() {
+		return System.getProperty("NAMESPACE");
+	}
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/AuthHandlingFilter.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/AuthHandlingFilter.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+
+public class AuthHandlingFilter implements Filter {
+	
+	public static class OAuthCredentials {
+		private String token;
+		private String user;
+		
+		public OAuthCredentials(String token, String user) {
+			this.token = token;
+			this.user = user;
+		}
+		
+		public String getToken() {
+			return token;
+		}
+		public String getUser() {
+			return user;
+		}
+	}
+	
+	public static ThreadLocal<OAuthCredentials> threadOAuthCredentials  = new ThreadLocal<OAuthCredentials>();
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+	}
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+		HttpServletRequest req = (HttpServletRequest)request;
+		String accessToken = req.getHeader("X-Forwarded-Access-Token");
+		String user = req.getHeader("X-Forwarded-User");
+		System.out.println("URL =" + req.getRequestURI());
+		System.out.println("X-Forwarded-Access-Token = " + accessToken);
+		System.out.println("X-Forwarded-User = " + user);
+		OAuthCredentials creds = new OAuthCredentials(accessToken, user);
+		threadOAuthCredentials.set(creds);
+		chain.doFilter(request, response);
+	}
+
+	@Override
+	public void destroy() {
+	}
+
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
@@ -621,26 +621,26 @@ public class KomodoRestV1Application extends Application implements SystemConsta
             //
             PersistenceType persistenceType = PersistenceType.PGSQL;
             String pType = System.getProperty(REPOSITORY_PERSISTENCE_TYPE);
-            if (PersistenceType.H2.name().equals(pType))
+            if (PersistenceType.H2.name().equals(pType)) {
                 persistenceType = PersistenceType.H2;
-
-            //
-            // Configure properties for persistence connection
-            //
-            String persistenceHost = System.getProperty(REPOSITORY_PERSISTENCE_HOST);
-            if (persistenceHost == null)
-                System.setProperty(REPOSITORY_PERSISTENCE_HOST, "localhost"); // default to localhost if not set
-
-            System.setProperty(REPOSITORY_CONNECTION_URL, persistenceType.getConnUrl());
-            System.setProperty(REPOSITORY_BINARY_STORE_URL, persistenceType.getBinaryStoreUrl());
-            System.setProperty(REPOSITORY_CONNECTION_DRIVER, persistenceType.getDriver());
-
+            }
+            if (System.getProperty(REPOSITORY_PERSISTENCE_CONNECTION_URL) == null) {
+            	System.setProperty(REPOSITORY_PERSISTENCE_CONNECTION_URL, persistenceType.getConnUrl());
+            }
+            if (System.getProperty(REPOSITORY_PERSISTENCE_BINARY_STORE_URL) == null) {
+            	System.setProperty(REPOSITORY_PERSISTENCE_BINARY_STORE_URL, persistenceType.getBinaryStoreUrl());
+            }
+            if (System.getProperty(REPOSITORY_PERSISTENCE_CONNECTION_DRIVER) == null) {
+            	System.setProperty(REPOSITORY_PERSISTENCE_CONNECTION_DRIVER, persistenceType.getDriver());
+            }
+            
             //
             // No preStartCheck for H2 as its generated upon first repository connection
             // Other persistence types are external so do require this.
             //
-            if(persistenceType.isExternal())
+            if(persistenceType.isExternal()) {
                 preStartCheck(persistenceType);
+            }
 
         } catch (Exception ex) {
             throw new WebApplicationException(ex, Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
@@ -781,14 +781,11 @@ public class KomodoRestV1Application extends Application implements SystemConsta
         java.sql.Connection connection = null;
         String connUrl = persistenceType.getEvaluatedConnUrl();
         try  {
-            connection = DriverManager.getConnection(connUrl,
-                                                                        REPOSITORY_PERSISTENCE_USERNAME,
-                                                                        REPOSITORY_PERSISTENCE_PASSWORD);
+			connection = DriverManager.getConnection(connUrl, ApplicationProperties.getRepositoryPersistenceUser(),
+					ApplicationProperties.getRepositoryPersistencePassword());
         } catch (Exception ex) {
-            throw new WebApplicationException("Failed to connect to " + persistenceType.name() + " database: " +
-                                                                                     connUrl + SEMI_COLON +
-                                                                                    REPOSITORY_PERSISTENCE_USERNAME + COLON +
-                                                                                    REPOSITORY_PERSISTENCE_PASSWORD, ex);
+        	// this is a check do not throw a exception, not put passwords in log.
+        	KLog.getLogger().info("Failed to connect to " + persistenceType.name() + " database: " + persistenceType.getConnUrl());
         } finally {
             if(connection != null) {
                 try {

--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoService.java
@@ -58,6 +58,7 @@ import org.komodo.rest.relational.RestEntityFactory;
 import org.komodo.rest.relational.connection.RestConnection;
 import org.komodo.rest.relational.json.KomodoJsonMarshaller;
 import org.komodo.spi.KException;
+import org.komodo.spi.constants.SystemConstants;
 import org.komodo.spi.lexicon.datavirt.DataVirtLexicon;
 import org.komodo.spi.lexicon.vdb.VdbLexicon;
 import org.komodo.spi.repository.KomodoObject;
@@ -76,7 +77,6 @@ import com.google.gson.Gson;
 public abstract class KomodoService implements V1Constants {
 
     public static final String KOMODO_USER = "anonymous";
-    public static final String DEV_MODE = "DEV_MODE";
 
     protected static final KLog LOGGER = KLog.getLogger();
 
@@ -205,7 +205,7 @@ public abstract class KomodoService implements V1Constants {
     	if (AuthHandlingFilter.threadOAuthCredentials.get() != null) {
     		return new SecurityPrincipal(AuthHandlingFilter.threadOAuthCredentials.get().getUser(), null);	
     	}
-    	if (System.getProperty(DEV_MODE) != null) {
+    	if (Boolean.getBoolean(SystemConstants.DEV_MODE)) {
     		return new SecurityPrincipal(KOMODO_USER, null);
     	}
 		return new SecurityPrincipal(null, createErrorResponse(Status.UNAUTHORIZED,

--- a/server/komodo-rest/src/main/java/org/komodo/rest/TeiidSwarmMetadataInstance.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/TeiidSwarmMetadataInstance.java
@@ -21,12 +21,177 @@
  */
 package org.komodo.rest;
 
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeMap;
+
 import org.komodo.metadata.DefaultMetadataInstance;
 import org.komodo.metadata.TeiidConnectionProvider;
+import org.komodo.spi.KException;
+import org.komodo.spi.runtime.TeiidDataSource;
+import org.teiid.adminapi.Admin;
+import org.teiid.adminapi.AdminException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.kubernetes.client.LocalObjectReference;
+import io.kubernetes.client.ModelServiceCatalogClient;
+import io.kubernetes.client.ParametersFromSource;
+import io.kubernetes.client.Secret;
+import io.kubernetes.client.ServiceBinding;
+import io.kubernetes.client.ServiceBindingList;
+import io.kubernetes.client.ServiceInstance;
+import io.kubernetes.client.ServiceInstanceList;
 
 public class TeiidSwarmMetadataInstance extends DefaultMetadataInstance {
 
+	private static final String OSURL = "https://openshift.default.svc";
+	private static final String SC_VERSION = "v1beta1";
+	private ModelServiceCatalogClient scClient;
+	
     public TeiidSwarmMetadataInstance(TeiidConnectionProvider connectionProvider) {
 		super(connectionProvider);
+		this.scClient = new ModelServiceCatalogClient(OSURL, SC_VERSION);
 	}
+    
+    public Admin adminX() throws AdminException {
+    	return admin();
+    }
+    
+    @Override
+    public Collection<TeiidDataSource> getDataSources() throws KException {
+        checkStarted();
+        try {
+        	Collection<String> dsNames = admin().getDataSourceNames();
+        	String token = AuthHandlingFilter.threadOAuthCredentials.get().getToken();
+        	System.out.println("Access token = "+token);
+        	if (token != null) {
+        		this.scClient.setAuthHeader(token);
+        		
+        		ServiceInstanceList serviceList = this.scClient.getServiceInstances(ApplicationProperties.getNamespace());
+        		List<ServiceInstance> services = serviceList.getItems();
+        		if( services != null && !services.isEmpty()) {
+        			for (ServiceInstance svc:services) {
+        				String name = svc.getMetadata().getName();
+        				System.out.println("Service Name = "+name);
+        				if (svc.getStatus().isReady()) {
+        					if (!dsNames.contains(name)) {
+        						ServiceBinding binding = getServiceBinding(svc);
+        						if (binding == null) {
+        							binding = this.scClient.createServiceBinding(svc);
+        						}
+        						Map<String, String> parameters = getParameters(svc);
+        						Map<String, String> bindingSecrets = getBindingSecrets(binding);
+        						bindingSecrets.putAll(parameters);
+        						createDataSource(name, bindingSecrets);
+        					}
+        				} else {
+        					System.out.println(name+":service not ready");
+        				}
+        			}
+        		}
+        	}
+            return super.getDataSources();
+        } catch (Exception ex) {
+            throw handleError(ex);
+        }
+    }
+
+	private Map<String, String> getBindingSecrets(ServiceBinding binding) throws IOException {
+		Map<String, String> map = new TreeMap<>();
+		if (binding != null) {
+			String secretName = binding.getSpec().getSecretName();
+			Secret secret = this.scClient.getSecret(ApplicationProperties.getNamespace(), secretName);
+			map = secret.getData();
+			Map<String, String> decodedMap = new TreeMap<>();
+			for (Map.Entry<String, String> entry:map.entrySet()) {
+				String key = entry.getKey();
+				String encodedValue = entry.getValue();
+				decodedMap.put(key, new String(Base64.getDecoder().decode(encodedValue)));
+			}
+			map = decodedMap;
+		}
+		return map;
+	}
+
+	private ServiceBinding getServiceBinding(ServiceInstance svc) throws IOException {
+    	ServiceBindingList bindingList = this.scClient.getServiceBindings(ApplicationProperties.getNamespace());
+		List<ServiceBinding> bindings = bindingList.getItems();
+		if( bindings != null && !bindings.isEmpty()) {
+			for (ServiceBinding sb : bindings) {
+				LocalObjectReference ref = sb.getSpec().getServiceInstanceRef();
+				if (ref.getName().equals(svc.getMetadata().getName())) {
+					return sb;
+				}
+			}
+		}
+    	return null;
+    }
+    
+    private Map<String, String> getParameters(ServiceInstance svc) throws IOException {
+    	Map<String, String> map = new TreeMap<>();
+    	
+		// data source is there.
+		ParametersFromSource parameters = null;
+		for (int i = 0; i < svc.getSpec().getParametersFrom().size(); i++) {
+			parameters = svc.getSpec().getParametersFrom().get(i);
+			if(parameters.getSecretKeyRef().getKey().equalsIgnoreCase("parameters")) {
+				break;
+			}
+		}
+		if (parameters != null) {
+			String secretName = parameters.getSecretKeyRef().getName();
+			String key = parameters.getSecretKeyRef().getKey();
+			Secret secret = this.scClient.getSecret(ApplicationProperties.getNamespace(),
+					secretName);
+			if (secret != null) {
+				String json = secret.getData().get(key);
+				map = new ObjectMapper().readerFor(Map.class).readValue(Base64.getDecoder().decode(json));					
+			}
+		} else {
+			System.out.println(svc.getMetadata().getName()+":No Parameters Secret found");
+		}  
+		return map;
+    }
+    
+	private void createDataSource(String name, Map<String, String> map) throws AdminException {
+		if (map.get("POSTGRESQL_DATABASE") != null) {
+			System.out.println("Creating the Datasource = "+name + " with properties ="+map);
+			/*
+			 {
+			   "DATABASE_SERVICE_NAME":"postgresql",
+			   "MEMORY_LIMIT":"512Mi",
+			   "NAMESPACE":"openshift",
+			   "database_name":"sampledb",
+			   "password":"pass",
+			   "username":"user",
+			   "uri": "postgres://172.30.145.26:5432",
+			   "POSTGRESQL_VERSION":"9.5",
+			   "VOLUME_CAPACITY":"1Gi"
+			}
+			*/
+			String driverName = null;
+			Set<String> templateNames = admin().getDataSourceTemplateNames();
+			System.out.println("template names:"+templateNames);
+			for (String template : templateNames) {
+				// TODO: there is null entering from above call from ,getDataSourceTemplateNames need to investigate why
+				if (template != null && template.startsWith("postgresql")) {
+					driverName = template;
+					break;
+				}
+			}
+			Properties props = new Properties();
+			props.setProperty("connection-url", "jdbc:postgresql://" + map.get("DATABASE_SERVICE_NAME") + ":5432/"
+					+ map.get("database_name"));
+			props.setProperty("user-name", map.get("username"));
+			props.setProperty("password", map.get("password"));
+			admin().createDataSource(name, driverName, props);
+		}
+	}
+    
 }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoMetadataService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoMetadataService.java
@@ -35,7 +35,9 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
+
 import javax.naming.InitialContext;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
@@ -55,6 +57,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
+
 import org.komodo.core.KEngine;
 import org.komodo.importer.ImportMessages;
 import org.komodo.importer.ImportOptions;
@@ -71,6 +74,7 @@ import org.komodo.rest.CallbackTimeoutException;
 import org.komodo.rest.KomodoRestException;
 import org.komodo.rest.KomodoRestV1Application.V1Constants;
 import org.komodo.rest.KomodoService;
+import org.komodo.rest.TeiidSwarmMetadataInstance;
 import org.komodo.rest.relational.KomodoProperties;
 import org.komodo.rest.relational.RelationalMessages;
 import org.komodo.rest.relational.connection.RestConnection;
@@ -112,10 +116,12 @@ import org.komodo.utils.ArgCheck;
 import org.komodo.utils.FileUtils;
 import org.komodo.utils.ModelType.Type;
 import org.komodo.utils.StringUtils;
+import org.teiid.adminapi.Admin;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -1175,6 +1181,28 @@ public class KomodoMetadataService extends KomodoService {
         }
     }
 
+    @GET
+    @Path("test")
+    @Produces( MediaType.APPLICATION_JSON )
+    @ApiOperation(value = "Test", response = String.class)
+    @ApiResponses(value = {
+        @ApiResponse(code = 403, message = "An error has occurred.")
+    })
+    public String test(final @Context HttpHeaders headers,
+                                   final @Context UriInfo uriInfo) throws KomodoRestException {
+    	try {
+    		TeiidSwarmMetadataInstance mi = (TeiidSwarmMetadataInstance)getMetadataInstance();
+    		Admin admin = mi.adminX();
+			Properties props = new Properties();
+			props.setProperty("connection-url", "jdbc:postgresql://db02.mw.lab.eng.bos.redhat.com:5432/bqt2");
+			props.setProperty("user-name", "bqt2");
+			props.setProperty("password", "mm");
+			admin.createDataSource("my-postgres", "postgresql", props);
+    	} catch (Exception e) {
+    		
+    	}
+    	return "{\"result\": \"executed\"}";
+    }
     /**
      * @param headers
      *        the request headers (never <code>null</code>)

--- a/server/komodo-rest/src/main/webapp/WEB-INF/web.xml
+++ b/server/komodo-rest/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:web="http://xmlns.jcp.org/xml/ns/javaee"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+  <display-name>VDB-Builder</display-name>
+
+    <filter>
+        <filter-name>AuthHandlingFilter</filter-name>
+        <filter-class>org.komodo.rest.AuthHandlingFilter</filter-class>
+    </filter>
+    
+    <filter-mapping>
+        <filter-name>AuthHandlingFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+</web-app>

--- a/server/komodo-rest/src/main/webapp/index.html
+++ b/server/komodo-rest/src/main/webapp/index.html
@@ -1,0 +1,8 @@
+<html>
+<title>Komodo Server</title>
+<body>
+	<h1>Komodo Server</h1>
+	<a href="api-docs">swagger-ui</a><p/>
+	<a href="v1/swagger.json">swagger.json</a>
+</body>
+</html>

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/AbstractFrameworkTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/AbstractFrameworkTest.java
@@ -23,11 +23,14 @@ package org.komodo.rest.service;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+
+import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.attribute.FileAttribute;
 import javax.ws.rs.core.MediaType;
 import org.apache.http.HttpEntity;
@@ -84,14 +87,20 @@ public class AbstractFrameworkTest implements StringConstants, V1Constants {
 
     @BeforeClass
     public static void beforeAllFramework() throws Exception {
-        _kengineDataDir = Files.createTempDirectory(null, new FileAttribute[0]);
-        System.setProperty(SystemConstants.ENGINE_DATA_DIR, _kengineDataDir.toString());
+    	_kengineDataDir = Paths.get("target/KomodoEngineDataDir");    	
+    	File f = new File (_kengineDataDir.toAbsolutePath().toString());
+    	if (f.exists()) {
+    		f.delete();
+    	} else {
+    		Files.createDirectory(_kengineDataDir, new FileAttribute[0]);    		
+    	}
+        System.setProperty(SystemConstants.ENGINE_DATA_DIR,  _kengineDataDir.toAbsolutePath().toString());
 
         //
         // Sets the persistence type to H2 for test purposes
         //
         System.setProperty(SystemConstants.REPOSITORY_PERSISTENCE_TYPE, PersistenceType.H2.name());
-        System.setProperty(KomodoService.DEV_MODE, "true");
+        System.setProperty(SystemConstants.DEV_MODE, "true");
     }
 
     @AfterClass
@@ -105,7 +114,7 @@ public class AbstractFrameworkTest implements StringConstants, V1Constants {
         } catch (Exception ex) {
             _kengineDataDir.toFile().deleteOnExit();
         }
-        System.setProperty(KomodoService.DEV_MODE, null);
+        System.setProperty(SystemConstants.DEV_MODE, "true");
     }
 
     protected HttpClient requestClient() {

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/AbstractFrameworkTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/AbstractFrameworkTest.java
@@ -91,6 +91,7 @@ public class AbstractFrameworkTest implements StringConstants, V1Constants {
         // Sets the persistence type to H2 for test purposes
         //
         System.setProperty(SystemConstants.REPOSITORY_PERSISTENCE_TYPE, PersistenceType.H2.name());
+        System.setProperty(KomodoService.DEV_MODE, "true");
     }
 
     @AfterClass
@@ -104,6 +105,7 @@ public class AbstractFrameworkTest implements StringConstants, V1Constants {
         } catch (Exception ex) {
             _kengineDataDir.toFile().deleteOnExit();
         }
+        System.setProperty(KomodoService.DEV_MODE, null);
     }
 
     protected HttpClient requestClient() {


### PR DESCRIPTION
1) Upgraded Teiid version to 10.0.0.Final
2) Also upgraded the WF-Swarm to reflect the version of the Teiid.
3) Changed the maven group ids to reflect the new version
4) Added a dependency on https://github.com/teiid/kubernetes-service-catalog-client project, which is library required to interact with service catalog (this needs to put in maven central too)
5) Added code to create a docker image based on F8 docker plug-in. This is helpful in releasing a final image, which is tested with the template image at https://github.com/rareddy/osb-data-services This project will be merged with @shawkins work on community-based images. These would be community deliverables.
6) The above template uses "oauth-proxy" to let user login into OpenShift, which is a http proxy
7) Based on headers from the "oauth-proxy" in the Komodo a AuthProxy has been added to inject the access-token an user name into a known context that is accessible to rest of the modules. At a later point, we will consider building a full security context based on these.
8) Also added a PG image to the template, which can be used as storage for modeshape.

With all above in place, if there is a Posgresql database that has been provisioned to the project, a call to  Komodo's rest api "/v1/metadata/connections" will contact the service broker and get list of services, and then, if required it will bind to the service (if not already bound), and will gather the properties required for to make connection from the OpenShift Secrets and using the Teiid's Admin API will create a connection, and then return the resulting connections available in the Komodo-Teiid engine.