### PR TITLE
TEIIDTOOLS-283: 

### DIFF
--- a/komodo-core/src/main/resources/org/komodo/core/repository/local-repository-config.json
+++ b/komodo-core/src/main/resources/org/komodo/core/repository/local-repository-config.json
@@ -20,15 +20,15 @@
             "type" : "db",
             "connectionUrl": "${komodo.connectionUrl}",
             "driver" : "${komodo.connectionDriver}",
-            "username" : "komodo",
-            "password" : "komodo"
+            "username" : "${komodo.user}",
+            "password" : "${komodo.password}"
         },
         "binaryStorage" : {
           "type"  : "database",
           "driverClass" : "${komodo.connectionDriver}",
           "url" : "${komodo.binaryStoreUrl}",
-          "username" : "komodo",
-          "password" : "komodo"
+          "username" : "${komodo.user}",
+          "password" : "${komodo.password}"
         },
         "transactionManagerLookup" : {
             "name" : "org.komodo.core.internal.repository.KTransactionManagerLookup" 

--- a/komodo-core/src/test/java/org/komodo/core/AbstractLoggingTest.java
+++ b/komodo-core/src/test/java/org/komodo/core/AbstractLoggingTest.java
@@ -22,16 +22,17 @@
 package org.komodo.core;
 
 import static org.junit.Assert.assertEquals;
+
 import java.io.File;
-import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.komodo.spi.constants.StringConstants;
-import org.komodo.spi.constants.SystemConstants;
 import org.komodo.spi.logging.KLogger.Level;
 import org.komodo.utils.FileUtils;
 import org.komodo.utils.KLog;
+import org.komodo.utils.TestKLog;
 
 /**
  * Configures the logging for tests and most importantly aims
@@ -73,8 +74,7 @@ public abstract class AbstractLoggingTest implements StringConstants {
     @BeforeClass
     public static void initLogging() throws Exception {
         // create data directory for engine logging
-        _dataDirectory = Files.createTempDirectory( "KomodoEngineDataDir" );
-        System.setProperty( SystemConstants.ENGINE_DATA_DIR, _dataDirectory.toString() );
+    	_dataDirectory = TestKLog.createEngineDirectory();        
 
         // Initialises logging and reduces modeshape logging from DEBUG to INFO
         configureLogPath(KLog.getLogger());

--- a/komodo-core/src/test/java/org/komodo/core/internal/TestObjectOperations.java
+++ b/komodo-core/src/test/java/org/komodo/core/internal/TestObjectOperations.java
@@ -26,14 +26,15 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.PathNotFoundException;
@@ -45,6 +46,7 @@ import javax.jcr.Session;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
 import javax.jcr.query.QueryResult;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -52,12 +54,12 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.komodo.spi.constants.StringConstants;
-import org.komodo.spi.constants.SystemConstants;
 import org.komodo.spi.lexicon.LexiconConstants.JcrLexicon;
 import org.komodo.spi.lexicon.LexiconConstants.NTLexicon;
 import org.komodo.test.utils.TestUtilities;
 import org.komodo.utils.FileUtils;
 import org.komodo.utils.KLog;
+import org.komodo.utils.TestKLog;
 import org.modeshape.common.collection.Problem;
 import org.modeshape.common.collection.Problems;
 import org.modeshape.jcr.JcrRepository;
@@ -81,8 +83,7 @@ public class TestObjectOperations implements StringConstants {
 
     @BeforeClass
     public static void oneTimeSetup() throws Exception {
-        _dataDirectory = Files.createTempDirectory( "KomodoEngineDataDir" );
-        System.setProperty( SystemConstants.ENGINE_DATA_DIR, _dataDirectory.toString() );
+        _dataDirectory = TestKLog.createEngineDirectory(); 	
     }
 
     @AfterClass

--- a/komodo-metadata-instance/pom.xml
+++ b/komodo-metadata-instance/pom.xml
@@ -24,12 +24,12 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.jboss.teiid</groupId>
+			<groupId>org.teiid</groupId>
 			<artifactId>teiid-engine</artifactId>
 		</dependency>
 
 		<dependency>
-			<groupId>org.jboss.teiid</groupId>
+			<groupId>org.teiid</groupId>
 			<artifactId>teiid-admin</artifactId>
 		</dependency>
 

--- a/komodo-metadata-instance/src/main/java/org/komodo/metadata/DefaultMetadataInstance.java
+++ b/komodo-metadata-instance/src/main/java/org/komodo/metadata/DefaultMetadataInstance.java
@@ -52,6 +52,7 @@ import org.komodo.spi.query.QSColumn;
 import org.komodo.spi.query.QSResult;
 import org.komodo.spi.query.QSRow;
 import org.komodo.spi.runtime.ConnectionDriver;
+import org.komodo.spi.runtime.ServiceCatalogDataSource;
 import org.komodo.spi.runtime.TeiidDataSource;
 import org.komodo.spi.runtime.TeiidPropertyDefinition;
 import org.komodo.spi.runtime.TeiidTranslator;
@@ -122,7 +123,7 @@ public class DefaultMetadataInstance implements MetadataInstance {
         this.connectionProvider = connectionProvider;
     }
 
-    private Admin admin() throws AdminException {
+    protected Admin admin() throws AdminException {
     	return connectionProvider.getAdmin();
     }
     
@@ -133,7 +134,7 @@ public class DefaultMetadataInstance implements MetadataInstance {
      *        the error being handled (cannot be <code>null</code>)
      * @return the error (never <code>null</code>)
      */
-    private static KException handleError(Throwable e) {
+    protected static KException handleError(Throwable e) {
         assert (e != null);
     
         if (e instanceof KException) {
@@ -143,7 +144,7 @@ public class DefaultMetadataInstance implements MetadataInstance {
         return new KException(e);
     }
 
-    private void checkStarted() throws KException {
+    protected void checkStarted() throws KException {
         if (getCondition() != Condition.REACHABLE) {
         	String msg = Messages.getString(Messages.MetadataServer.serverCanNotBeReached);
 	        throw new KException(msg);
@@ -740,4 +741,14 @@ public class DefaultMetadataInstance implements MetadataInstance {
             throw handleError(ex);
         }
     }
+
+	@Override
+	public Set<ServiceCatalogDataSource> getServiceCatalogSources() throws KException {
+        throw new KException(Messages.getString(Messages.MetadataServer.notImplemented));
+	}
+
+	@Override
+	public void bindToServiceCatalogSource(String dsName) throws KException {
+		throw new KException(Messages.getString(Messages.MetadataServer.notImplemented));
+	}
 }

--- a/komodo-metadata-instance/src/main/java/org/komodo/metadata/Messages.java
+++ b/komodo-metadata-instance/src/main/java/org/komodo/metadata/Messages.java
@@ -55,7 +55,8 @@ public class Messages implements StringConstants {
         refreshError,
         cannotRefreshError,
         serverCanNotBeReached,
-        startStopFailure;
+        startStopFailure,
+        notImplemented;
 
         @Override
         public String toString() {

--- a/komodo-metadata-instance/src/main/resources/org/komodo/metadata/messages.properties
+++ b/komodo-metadata-instance/src/main/resources/org/komodo/metadata/messages.properties
@@ -49,3 +49,4 @@ MetadataServer.refreshError = An error occurred while attempting to refresh the 
 MetadataServer.startStopFailure = An error occurred while attempting to send a command to the metadata instance: "{0}"
 MetadataServer.cannotRefreshError = The server instance can not be refreshed.
 MetadataServer.serverCanNotBeReached = The server is down and can't be reached currently. Retry.
+MetadataServer.notImplemented = The method is not implemented

--- a/komodo-openshift/scripts/komodo-teiid-wildfly-swarm-s2i.json
+++ b/komodo-openshift/scripts/komodo-teiid-wildfly-swarm-s2i.json
@@ -492,8 +492,8 @@
                                     },
                                     {
                                     	"name": "SWARM_JAR_ARGS",
-                                    	"value": "-DREPOSITORY_PERSISTENCE_HOST=vdb-builder-persistence"
-                                    },
+                                    	"value": "-Dkomodo.user=komodo -Dkomodo.password=komodo -Dkomodo.connectionUrl=jdbc:postgresql://vdb-builder-persistence:5432/komodo -Dkomodo.binaryStoreUrl=jdbc:postgresql://vdb-builder-persistence:5432/komodo -Dkomodo.connectionDriver=org.postgresql.Driver"
+                                    },                                    
                                     {
                                         "name": "TEIID_USERNAME",
                                         "value": "${TEIID_USERNAME}"

--- a/komodo-parent/pom.xml
+++ b/komodo-parent/pom.xml
@@ -131,7 +131,7 @@
 		<!-- dependencies from IP-BOM -->
 				
 		<version.commons.io>2.5</version.commons.io>
-		<version.org.teiid>9.3.2</version.org.teiid>
+		<version.org.teiid>10.0.0.Final</version.org.teiid>
 
 		<!-- Instruct the build to use only UTF-8 encoding for source code -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -151,8 +151,6 @@
 		<!-- The version of jgit -->
 		<version.jgit>4.4.1.201607150455-r</version.jgit>
 
-		<version.wildfly>2.2.1.Final</version.wildfly>
-
 		<version.aesh>0.33.12.redhat-1</version.aesh>
 		<version.org.jboss.dmr>1.3.0.Final</version.org.jboss.dmr>
 
@@ -163,7 +161,7 @@
 		<version.teiid.modeshape>0.0.1-SNAPSHOT</version.teiid.modeshape>
 		<version.postgresql>42.1.4</version.postgresql>
 		<version.xerces>2.9.1</version.xerces>		
-		<version.wildfly.swarm>2017.12.0-SNAPSHOT</version.wildfly.swarm>
+		<version.wildfly.swarm>2017.12.1</version.wildfly.swarm>
 		<version.gson>2.2.4</version.gson>
 		<version.apache.commons.codec>1.10</version.apache.commons.codec>
 		<version.guava>16.0.1</version.guava>
@@ -174,7 +172,9 @@
 		<version.resteasy>3.0.19.Final</version.resteasy>
 		<version.jboss.logging>3.3.0.Final</version.jboss.logging>
 		<version.org.mockito>1.10.19</version.org.mockito>	
-		<version.com.fasterxml.jackson>2.7.4</version.com.fasterxml.jackson>			
+		<version.com.fasterxml.jackson>2.7.4</version.com.fasterxml.jackson>
+        <version.org.osb>1.0.0-SNAPSHOT</version.org.osb>
+        <org.apache.httpcomponents.version>4.5.3</org.apache.httpcomponents.version>			
 	</properties>
 
 	<!-- This section defines the default dependency settings inherited by child 
@@ -339,37 +339,37 @@
 			</dependency>
 
 			<dependency>
-				<groupId>org.jboss.teiid</groupId>
+				<groupId>org.teiid</groupId>
 				<artifactId>teiid-common-core</artifactId>
 				<version>${version.org.teiid}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jboss.teiid</groupId>
+				<groupId>org.teiid</groupId>
 				<artifactId>teiid-api</artifactId>
 				<version>${version.org.teiid}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jboss.teiid</groupId>
+				<groupId>org.teiid</groupId>
 				<artifactId>teiid-engine</artifactId>
 				<version>${version.org.teiid}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jboss.teiid</groupId>
+				<groupId>org.teiid</groupId>
 				<artifactId>teiid-runtime</artifactId>
 				<version>${version.org.teiid}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jboss.teiid</groupId>
+				<groupId>org.teiid</groupId>
 				<artifactId>teiid-admin</artifactId>
 				<version>${version.org.teiid}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jboss.teiid</groupId>
+				<groupId>org.teiid</groupId>
 				<artifactId>teiid-jboss-admin</artifactId>
 				<version>${version.org.teiid}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jboss.teiid</groupId>
+				<groupId>org.teiid</groupId>
 				<artifactId>teiid-client</artifactId>
 				<version>${version.org.teiid}</version>
 			</dependency>
@@ -378,6 +378,17 @@
 				<artifactId>teiid-jdbc</artifactId>
 				<version>${version.wildfly.swarm}</version>
 			</dependency>
+      
+            <dependency>
+              <groupId>org.osb</groupId>
+              <artifactId>kubernetes-service-catalog-client</artifactId>
+              <version>${version.org.osb}</version>        
+            </dependency>   
+            <dependency>
+              <groupId>org.apache.httpcomponents</groupId>
+              <artifactId>httpclient</artifactId>
+              <version>${org.apache.httpcomponents.version}</version>
+            </dependency>                
 
 			<!--Inherited from BOM, but changes the default scope to "test" -->
 			<dependency>
@@ -391,17 +402,6 @@
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
 				<version>${version.commons.io}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.wildfly.core</groupId>
-				<artifactId>wildfly-cli</artifactId>
-				<version>${version.wildfly}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.wildfly.core</groupId>
-				<artifactId>wildfly-controller-client</artifactId>
-				<version>${version.wildfly}</version>
 			</dependency>
 
 			<dependency>

--- a/komodo-relational/pom.xml
+++ b/komodo-relational/pom.xml
@@ -36,22 +36,6 @@
 			<artifactId>komodo-importer</artifactId>
 		</dependency>
 
-<!-- 		<dependency>
-			<groupId>org.wildfly.core</groupId>
-			<artifactId>wildfly-cli</artifactId>
-	        <exclusions>
-	            <exclusion>
-	                <groupId>sun.jdk</groupId>
-	                <artifactId>jconsole</artifactId>
-	            </exclusion>
-	        </exclusions>				
-		</dependency>
-			
-		<dependency>
-			<groupId>org.wildfly.core</groupId>
-			<artifactId>wildfly-controller-client</artifactId>
-		</dependency> -->
-
 		<dependency>
 			<groupId>org.teiid.komodo</groupId>
 			<artifactId>komodo-utils</artifactId>

--- a/komodo-spi/src/main/java/org/komodo/spi/constants/SystemConstants.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/constants/SystemConstants.java
@@ -50,36 +50,30 @@ public interface SystemConstants extends StringConstants {
     String REPOSITORY_PERSISTENCE_TYPE = "REPOSITORY_PERSISTENCE_TYPE";
 
     /**
-     * The environment variable that defines the name of the host where the persistence store is located
-     * Cannot use 'komodo.' prefix since Openshift considers this invalid.
-     */
-    String REPOSITORY_PERSISTENCE_HOST = "REPOSITORY_PERSISTENCE_HOST";
-
-    /**
      * The environment variable that defines the connection url of the persistence database.
      * Values should be in the format "jdbc:<type>:<path>"
      */
-    String REPOSITORY_CONNECTION_URL = "komodo.connectionUrl";
+    String REPOSITORY_PERSISTENCE_CONNECTION_URL = "komodo.connectionUrl";
 
     /**
      * The environment variable that defines the connection url to the binary store of
      * the persistence database.
      * Values should be in the format "jdbc:<type>:<path>"
      */
-    String REPOSITORY_BINARY_STORE_URL = "komodo.binaryStoreUrl";
+    String REPOSITORY_PERSISTENCE_BINARY_STORE_URL = "komodo.binaryStoreUrl";
 
     /**
      * The environment variable that defines the driver used for connection to the persistence database
      */
-    String REPOSITORY_CONNECTION_DRIVER = "komodo.connectionDriver";
+    String REPOSITORY_PERSISTENCE_CONNECTION_DRIVER = "komodo.connectionDriver";
 
     /**
      * The repository persistence username
      */
-    String REPOSITORY_PERSISTENCE_USERNAME = "komodo";
+    String REPOSITORY_PERSISTENCE_CONNECTION_USERNAME = "komodo.user";
 
     /**
      * The repository persistence password
      */
-    String REPOSITORY_PERSISTENCE_PASSWORD = "komodo";
+    String REPOSITORY_PERSISTENCE_CONNECTION_PASSWORD = "komodo.password";
 }

--- a/komodo-spi/src/main/java/org/komodo/spi/lexicon/servicecatalog/ServiceCatalogLexicon.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/lexicon/servicecatalog/ServiceCatalogLexicon.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.spi.lexicon.servicecatalog;
+
+/**
+ * Constants associated with the DataVirtualization namespace
+ */
+public interface ServiceCatalogLexicon {
+
+    /**
+     * The URI and prefix constants of the DV namespace.
+     */
+    interface Namespace {
+        /**
+         * The service catalog namespace prefix. Value is {@value}.
+         */
+        String PREFIX = "sc";
+
+        /**
+         * The service catalog namespace URI. Value is {@value}.
+         */
+        String URI = "http://www.jboss.org/sc/1.0";
+    }
+    
+    interface DataService {
+        /**
+         * The name of the property whose value contains the data service name. Value is {@value}.
+         */
+        String NAME = Namespace.PREFIX + ":name";
+        
+        /**
+         * The name of the property whose value contains the data service type. Value is {@value}.
+         */
+        String TYPE = Namespace.PREFIX + ":type";        
+
+        /**
+         * The name of the property whose value contains the data service is bound or not. Value is {@value}.
+         */
+        String BOUND = Namespace.PREFIX + ":bound";           
+    }
+}

--- a/komodo-spi/src/main/java/org/komodo/spi/metadata/MetadataInstance.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/metadata/MetadataInstance.java
@@ -32,6 +32,7 @@ import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.outcome.Outcome;
 import org.komodo.spi.query.QSResult;
 import org.komodo.spi.runtime.ConnectionDriver;
+import org.komodo.spi.runtime.ServiceCatalogDataSource;
 import org.komodo.spi.runtime.TeiidDataSource;
 import org.komodo.spi.runtime.TeiidPropertyDefinition;
 import org.komodo.spi.runtime.TeiidTranslator;
@@ -403,4 +404,20 @@ public interface MetadataInstance extends StringConstants {
      * @throws KException 
      */
     void refresh() throws KException;
+    
+    
+    /**
+     * Gets available data service instances in the OpenShift's Service Catalog
+     * @return
+     * @throws KException
+     */
+    Set<ServiceCatalogDataSource> getServiceCatalogSources() throws KException;
+    
+    /**
+     * Binds the to the service catalog based source if needed and then creates the connection
+     * in the Teiid.
+     * @param dsName - Name of the Service Catalog data service
+     * @throws KException
+     */
+    void bindToServiceCatalogSource(String dsName) throws KException;
 }

--- a/komodo-spi/src/main/java/org/komodo/spi/repository/KomodoType.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/repository/KomodoType.java
@@ -276,7 +276,12 @@ public enum KomodoType {
     /**
      * Type for a data service UDF file entry.
      */
-    UDF_ENTRY;
+    UDF_ENTRY,
+    
+    /**
+     * Data Source from Service Catalog 
+     */
+    SERVICE_CATALOG_DATA_SOURCE;
 
     private Collection<String> aliases;
 

--- a/komodo-spi/src/main/java/org/komodo/spi/repository/PersistenceType.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/repository/PersistenceType.java
@@ -36,8 +36,8 @@ public enum PersistenceType {
     /**
      * PostgreSQL database used for production
      */
-    PGSQL ("jdbc:postgresql://${REPOSITORY_PERSISTENCE_HOST}/komodo",
-                   "org.postgresql.Driver", true);
+    PGSQL (System.getProperty(SystemConstants.REPOSITORY_PERSISTENCE_CONNECTION_URL),
+    		System.getProperty(SystemConstants.REPOSITORY_PERSISTENCE_CONNECTION_DRIVER), true);
 
     private String connUrl;
 
@@ -79,12 +79,14 @@ public enum PersistenceType {
      * @return the connection url with any know system properties replaced with their values
      */
     public String getEvaluatedConnUrl() {
-        String url = substitute(connUrl, SystemConstants.ENGINE_DATA_DIR);
-        url = substitute(connUrl, SystemConstants.REPOSITORY_PERSISTENCE_HOST);
+        String url = substitute(getConnUrl(), SystemConstants.ENGINE_DATA_DIR);
         return url;
     }
 
     public String getBinaryStoreUrl() {
+    	if (binaryUrl == null) {
+    		return getConnUrl();
+    	}
         return binaryUrl;
     }
 
@@ -92,15 +94,22 @@ public enum PersistenceType {
      * @return the binary store url with any know system properties replaced with their values
      */
     public String getEvaluatedBinaryStoreUrl() {
-        String url = substitute(binaryUrl, SystemConstants.ENGINE_DATA_DIR);
-        url = substitute(binaryUrl, SystemConstants.REPOSITORY_PERSISTENCE_HOST);
+        String url = substitute(getBinaryStoreUrl(), SystemConstants.ENGINE_DATA_DIR);
         return url;
     }
 
     public String getDriver() {
         return driver;
     }
+    
+    public String getUser() {
+    	return System.getProperty(SystemConstants.REPOSITORY_PERSISTENCE_CONNECTION_USERNAME);
+    }
 
+    public String getPassword() {
+    	return System.getProperty(SystemConstants.REPOSITORY_PERSISTENCE_CONNECTION_PASSWORD);
+    }
+    
     /**
      * In cases like PGSQL, the data store is externally managed while H2 is internally managed.
      * This flag distinguishes between the two types of store.

--- a/komodo-spi/src/main/java/org/komodo/spi/runtime/ServiceCatalogDataSource.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/runtime/ServiceCatalogDataSource.java
@@ -1,0 +1,46 @@
+/*************************************************************************************
+ * JBoss, Home of Professional Open Source.
+* See the COPYRIGHT.txt file distributed with this work for information
+* regarding copyright ownership. Some portions may be licensed
+* to Red Hat, Inc. under one or more contributor license agreements.
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this library; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+* 02110-1301 USA.
+ ************************************************************************************/
+package org.komodo.spi.runtime;
+
+/**
+ * Service catalog based Data Services that are available
+ *
+ */
+public interface ServiceCatalogDataSource {
+    /**
+     * @return real name of data source, maybe different from display name
+     */
+    String getName();
+
+    /**
+     * Returns the data source type name
+     * 
+     * @return the type
+     */
+    String getType();
+    
+    /**
+     * true if the data source is already bound to the current project.
+     * @return
+     */
+    boolean isBound();
+}

--- a/komodo-utils/pom.xml
+++ b/komodo-utils/pom.xml
@@ -23,7 +23,6 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/komodo-utils/src/test/java/org/komodo/utils/TestKLog.java
+++ b/komodo-utils/src/test/java/org/komodo/utils/TestKLog.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -33,6 +34,10 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileAttribute;
+import java.util.concurrent.ThreadLocalRandom;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -40,8 +45,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.komodo.spi.constants.SystemConstants;
 import org.komodo.spi.logging.KLogger;
-import org.komodo.utils.FileUtils;
-import org.komodo.utils.KLog;
 
 /**
  *
@@ -54,10 +57,23 @@ public class TestKLog {
     @BeforeClass
     public static void initDataDirectory() throws Exception {
         // create data directory for engine logging
-        _dataDirectory = Files.createTempDirectory( "KomodoEngineDataDir" );
-        System.setProperty( SystemConstants.ENGINE_DATA_DIR, _dataDirectory.toString() );
+        _dataDirectory = createEngineDirectory();	
+    	File f = new File (_dataDirectory.toAbsolutePath().toString());
+    	if (f.exists()) {
+    		f.delete();
+    	} else {
+    		Files.createDirectory(_dataDirectory, new FileAttribute[0]);    		
+    	}
+        System.setProperty(SystemConstants.ENGINE_DATA_DIR,  _dataDirectory.toAbsolutePath().toString());     	
     }
 
+	public static Path createEngineDirectory() throws IOException {
+		Path engineDir = Paths.get("target/KomodoEngineDataDir"+ThreadLocalRandom.current().nextInt());    	
+		Files.createDirectory(engineDir, new FileAttribute[0]);    		
+        System.setProperty(SystemConstants.ENGINE_DATA_DIR,  engineDir.toAbsolutePath().toString());
+        return engineDir;
+	}    
+    
     @AfterClass
     public static void removeDataDirectory() throws Exception {
         FileUtils.removeDirectoryAndChildren( _dataDirectory.toFile() );

--- a/server/komodo-rest/docker/Dockerfile
+++ b/server/komodo-rest/docker/Dockerfile
@@ -1,0 +1,8 @@
+#######################################################################
+# This is from fabric8 plugin uses for WildFly-Swarm                 #
+#######################################################################
+
+FROM registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift
+ENV AB_JOLOKIA_OFF=true AB_OFF=true JAVA_APP_DIR=/deployments
+EXPOSE 8080 8778 9779
+COPY maven /deployments/

--- a/server/komodo-rest/pom.xml
+++ b/server/komodo-rest/pom.xml
@@ -25,7 +25,7 @@
 		<app.rest.version>${project.version}</app.rest.version>
 		<app.rest.description>A tool that allows creating, editing and managing dynamic VDBs and their contents</app.rest.description>
 		<!-- Must remain all on one line. Otherwise, VFSUtils.readManifest complains of invalid header -->
-		<manifest.dependencies>org.jboss.logging,org.jboss.teiid.api,org.jboss.teiid.admin,org.jboss.teiid.common-core,org.jboss.teiid,org.jboss.teiid.client,io.swagger,com.fasterxml.jackson.core.jackson-core,com.fasterxml.jackson.core.jackson-databind,com.fasterxml.jackson.core.jackson-annotations</manifest.dependencies>
+		<manifest.dependencies>org.jboss.logging,org.jboss.teiid.api,org.jboss.teiid.admin,org.jboss.teiid.common-core,org.jboss.teiid,org.jboss.teiid.client,io.swagger,com.fasterxml.jackson.core.jackson-core,com.fasterxml.jackson.core.jackson-databind,com.fasterxml.jackson.core.jackson-annotations,org.jboss.as.cli,org.jboss.as.controller,org.jboss.dmr</manifest.dependencies>
 	</properties>
 
 	<dependencies>
@@ -34,7 +34,7 @@
 			<artifactId>komodo-relational</artifactId>
             <exclusions>
               <exclusion>
-                <groupId>org.jboss.teiid</groupId>
+                <groupId>org.teiid</groupId>
                 <artifactId>*</artifactId>
               </exclusion>
             </exclusions>
@@ -75,37 +75,37 @@
         </dependency>               			
     
 		<dependency>
-			<groupId>org.jboss.teiid</groupId>
+			<groupId>org.teiid</groupId>
 			<artifactId>teiid-api</artifactId>
 			<scope>provided</scope>
 		</dependency> 
 		<dependency>
-			<groupId>org.jboss.teiid</groupId>
+			<groupId>org.teiid</groupId>
 			<artifactId>teiid-client</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jboss.teiid</groupId>
+			<groupId>org.teiid</groupId>
 			<artifactId>teiid-engine</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jboss.teiid</groupId>
+			<groupId>org.teiid</groupId>
 			<artifactId>teiid-common-core</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jboss.teiid</groupId>
+			<groupId>org.teiid</groupId>
 			<artifactId>teiid-admin</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jboss.teiid</groupId>
+			<groupId>org.teiid</groupId>
 			<artifactId>teiid-jboss-admin</artifactId>
 			<scope>provided</scope>
             <exclusions>
               <exclusion>
-                <groupId>org.jboss.teiid</groupId>
+                <groupId>org.teiid</groupId>
                 <artifactId>*</artifactId>
               </exclusion>
             </exclusions>
@@ -127,12 +127,11 @@
 			<artifactId>teiid-jdbc</artifactId>
             <exclusions>
               <exclusion>
-                <groupId>org.jboss.teiid</groupId>
+                <groupId>org.teiid</groupId>
                 <artifactId>*</artifactId>
               </exclusion>
             </exclusions>      
 		</dependency>
-
 	    <dependency>
 	      <groupId>javax</groupId>
 	      <artifactId>javaee-api</artifactId>
@@ -146,9 +145,7 @@
         <dependency>
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpclient</artifactId>
-          <version>4.5.3</version>
         </dependency>   
-	
   		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
@@ -169,6 +166,20 @@
 		    <artifactId>jackson-annotations</artifactId>
 		    <scope>provided</scope>
 		</dependency>	
+        <dependency>
+          <groupId>org.osb</groupId>
+          <artifactId>kubernetes-service-catalog-client</artifactId>
+            <exclusions>
+              <exclusion>
+    			<groupId>com.fasterxml.jackson.core</groupId>
+    			<artifactId>*</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+              </exclusion>
+            </exclusions>                   
+        </dependency>
 
         <!-- Test Dependencies -->
 		<dependency>
@@ -307,6 +318,46 @@
 					</arguments>
 				</configuration>
 			</plugin>
+              <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.23.0</version>
+                <configuration>
+                  <registry>registry.hub.docker.com</registry>
+                  <images>
+                    <image>
+                      <name>teiid/komodo:${project.version}</name>
+                      <alias>komodo</alias>
+                      <build>
+                        <filter>@</filter>
+                        <dockerFileDir>${project.basedir}/docker</dockerFileDir>
+                        <assembly>
+                            <inline>
+                              <fileSets>
+                              <fileSet>
+                                <directory>${project.build.directory}</directory>
+                                <outputDirectory>/</outputDirectory>   
+                                <includes>
+                                  <include>**/*-swarm.jar</include>
+                                </includes>
+                              </fileSet>
+                             </fileSets>                            
+                            </inline>
+                        </assembly>
+                      </build>
+                    </image>                   
+                  </images>
+                </configuration>
+                <executions>
+                  <execution>
+                    <id>docker-build</id>
+                    <goals>
+                      <goal>build</goal>
+                      <goal>push</goal>
+                    </goals>
+                  </execution>
+                </executions>
+              </plugin>      
 		</plugins>
 	</build>
 

--- a/server/komodo-rest/src/main/java/org/komodo/rest/ApplicationProperties.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/ApplicationProperties.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest;
+
+import org.komodo.spi.constants.SystemConstants;
+
+public class ApplicationProperties implements SystemConstants{
+
+	public static String getNamespace() {
+		return System.getProperty("NAMESPACE");
+	}
+
+	public static String getRepositoryPersistenceDriver() {
+		return System.getProperty(REPOSITORY_PERSISTENCE_CONNECTION_DRIVER);
+	}
+	
+	public static String getRepositoryPersistenceURL() {
+		return System.getProperty(REPOSITORY_PERSISTENCE_CONNECTION_URL);
+	}
+	
+	public static String getRepositoryPersistenceUser() {
+		return System.getProperty(REPOSITORY_PERSISTENCE_CONNECTION_USERNAME);
+	}
+	
+	public static String getRepositoryPersistencePassword() {
+		return System.getProperty(REPOSITORY_PERSISTENCE_CONNECTION_PASSWORD);
+	}
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/AuthHandlingFilter.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/AuthHandlingFilter.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest;
+
+import java.io.IOException;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.ext.Provider;
+
+import org.komodo.utils.KLog;
+
+@Provider
+@PreMatching
+public class AuthHandlingFilter implements ContainerRequestFilter {
+	
+	public static class OAuthCredentials {
+		private String token;
+		private String user;
+		
+		public OAuthCredentials(String token, String user) {
+			this.token = token;
+			this.user = user;
+		}
+		
+		public String getToken() {
+			return token;
+		}
+		public String getUser() {
+			return user;
+		}
+	}
+	
+	public static ThreadLocal<OAuthCredentials> threadOAuthCredentials  = new ThreadLocal<OAuthCredentials>();
+
+	@Override
+	public void filter(ContainerRequestContext requestContext) throws IOException {
+		String accessToken = requestContext.getHeaderString("X-Forwarded-Access-Token");
+		String user = requestContext.getHeaderString("X-Forwarded-User");
+		KLog.getLogger().trace("URL =" + requestContext.getUriInfo());
+		KLog.getLogger().trace("X-Forwarded-Access-Token = " + accessToken);
+		KLog.getLogger().trace("X-Forwarded-User = " + user);
+		OAuthCredentials creds = new OAuthCredentials(accessToken, user);
+		threadOAuthCredentials.set(creds);		
+	}
+
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
@@ -25,6 +25,7 @@ import static org.komodo.rest.Messages.Error.KOMODO_ENGINE_CLEAR_TIMEOUT;
 import static org.komodo.rest.Messages.Error.KOMODO_ENGINE_SHUTDOWN_ERROR;
 import static org.komodo.rest.Messages.Error.KOMODO_ENGINE_SHUTDOWN_TIMEOUT;
 import static org.komodo.rest.Messages.Error.KOMODO_ENGINE_STARTUP_TIMEOUT;
+
 import java.io.File;
 import java.io.InputStream;
 import java.sql.DriverManager;
@@ -34,12 +35,14 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
 import javax.annotation.PreDestroy;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+
 import org.komodo.core.KEngine;
 import org.komodo.core.repository.LocalRepository;
 import org.komodo.core.repository.SynchronousCallback;
@@ -68,6 +71,7 @@ import org.komodo.rest.service.KomodoUtilService;
 import org.komodo.rest.service.KomodoVdbService;
 import org.komodo.rest.swagger.RestDataserviceConverter;
 import org.komodo.rest.swagger.RestPropertyConverter;
+import org.komodo.rest.swagger.RestServiceCatalogDataSourceConverter;
 import org.komodo.rest.swagger.RestVdbConditionConverter;
 import org.komodo.rest.swagger.RestVdbConverter;
 import org.komodo.rest.swagger.RestVdbDataRoleConverter;
@@ -84,12 +88,12 @@ import org.komodo.spi.lexicon.vdb.VdbLexicon;
 import org.komodo.spi.logging.KLogger.Level;
 import org.komodo.spi.metadata.MetadataInstance;
 import org.komodo.spi.repository.KomodoObject;
-import org.komodo.spi.repository.PersistenceType;
 import org.komodo.spi.repository.Repository;
 import org.komodo.spi.repository.Repository.UnitOfWork;
 import org.komodo.spi.repository.RepositoryClientEvent;
 import org.komodo.utils.KLog;
 import org.komodo.utils.observer.KLatchObserver;
+
 import io.swagger.converter.ModelConverters;
 
 /**
@@ -579,6 +583,16 @@ public class KomodoRestV1Application extends Application implements SystemConsta
          * The name of the URI ping type parameter
          */
         String PING_TYPE_PARAMETER = "pingType"; //$NON-NLS-1$
+        
+        /**
+         * Available sources from OpenShift Service catalog
+         */
+        String SERVICE_CATALOG_SOURCES = "serviceCatalogSources"; //$NON-NLS-1$
+        
+        /**
+         * Bing to available source in OpenShift Service catalog
+         */
+        String BIND_TO_SERVICE_CATALOG_SOURCE = "bindToServiceCatalogSource"; //$NON-NLS-1$        
     }
 
     private static final int TIMEOUT = 1;
@@ -615,32 +629,10 @@ public class KomodoRestV1Application extends Application implements SystemConsta
             corsHandler = initCorsHandler();
 
             //
-            // If the env variable REPOSITORY_PERSISTENCE_TYPE is defined then respect
-            // its value and set the persistence type accordingly. If not defined then assume
-            // PGSQL is required.
-            //
-            PersistenceType persistenceType = PersistenceType.PGSQL;
-            String pType = System.getProperty(REPOSITORY_PERSISTENCE_TYPE);
-            if (PersistenceType.H2.name().equals(pType))
-                persistenceType = PersistenceType.H2;
-
-            //
-            // Configure properties for persistence connection
-            //
-            String persistenceHost = System.getProperty(REPOSITORY_PERSISTENCE_HOST);
-            if (persistenceHost == null)
-                System.setProperty(REPOSITORY_PERSISTENCE_HOST, "localhost"); // default to localhost if not set
-
-            System.setProperty(REPOSITORY_CONNECTION_URL, persistenceType.getConnUrl());
-            System.setProperty(REPOSITORY_BINARY_STORE_URL, persistenceType.getBinaryStoreUrl());
-            System.setProperty(REPOSITORY_CONNECTION_DRIVER, persistenceType.getDriver());
-
-            //
             // No preStartCheck for H2 as its generated upon first repository connection
             // Other persistence types are external so do require this.
             //
-            if(persistenceType.isExternal())
-                preStartCheck(persistenceType);
+            checkRepoStorage();
 
         } catch (Exception ex) {
             throw new WebApplicationException(ex, Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
@@ -658,7 +650,7 @@ public class KomodoRestV1Application extends Application implements SystemConsta
         objs.add( new KomodoSearchService( this.kengine ));
         objs.add( new KomodoMetadataService( this.kengine ));
         objs.add( new KomodoImportExportService( this.kengine ));
-
+        objs.add(new AuthHandlingFilter());
         objs.add(corsHandler);
 
         this.singletons = Collections.unmodifiableSet( objs );
@@ -693,6 +685,7 @@ public class KomodoRestV1Application extends Application implements SystemConsta
         converters.addConverter(new RestVdbPermissionConverter());
         converters.addConverter(new RestVdbTranslatorConverter());
         converters.addConverter(new RestDataserviceConverter());
+        converters.addConverter(new RestServiceCatalogDataSourceConverter());
     }
 
     /**
@@ -766,38 +759,44 @@ public class KomodoRestV1Application extends Application implements SystemConsta
         return resources;
     }
 
+	public void validateRepositoryProperties() throws WebApplicationException {
+		if (ApplicationProperties.getRepositoryPersistenceDriver() == null
+				|| ApplicationProperties.getRepositoryPersistenceURL() == null) {
+			throw new WebApplicationException(
+					"Properties required to make connection to the repository storage missing");
+		}
+	}
+	
 	/**
 	 * Check there is a store for repository persistence.
 	 * @param persistenceType type of persistence store
 	 * @throws WebApplicationException
 	 */
-	private void preStartCheck(PersistenceType persistenceType) throws WebApplicationException {
-        try {
-            Class.forName(persistenceType.getDriver());
-        } catch (Exception ex) {
-            throw new WebApplicationException("Failed to initialised repository persistence driver", ex);
-        }
+	private void checkRepoStorage() throws WebApplicationException {
+		validateRepositoryProperties();
+		try {
+			Class.forName(ApplicationProperties.getRepositoryPersistenceDriver());
+		} catch (Exception ex) {
+			throw new WebApplicationException("Failed to initialise repository persistence driver", ex);
+		}
 
-        java.sql.Connection connection = null;
-        String connUrl = persistenceType.getEvaluatedConnUrl();
-        try  {
-            connection = DriverManager.getConnection(connUrl,
-                                                                        REPOSITORY_PERSISTENCE_USERNAME,
-                                                                        REPOSITORY_PERSISTENCE_PASSWORD);
-        } catch (Exception ex) {
-            throw new WebApplicationException("Failed to connect to " + persistenceType.name() + " database: " +
-                                                                                     connUrl + SEMI_COLON +
-                                                                                    REPOSITORY_PERSISTENCE_USERNAME + COLON +
-                                                                                    REPOSITORY_PERSISTENCE_PASSWORD, ex);
-        } finally {
-            if(connection != null) {
-                try {
-                    connection.close();
-                } catch (SQLException e) {
-                    // nothing to do
-                }
-            }
-        }
+		java.sql.Connection connection = null;
+		try {
+			connection = DriverManager.getConnection(ApplicationProperties.getRepositoryPersistenceURL(),
+					ApplicationProperties.getRepositoryPersistenceUser(),
+					ApplicationProperties.getRepositoryPersistencePassword());
+		} catch (Exception ex) {
+			KLog.getLogger().info(
+					"Failed to connect to database: " + ApplicationProperties.getRepositoryPersistenceURL());
+		} finally {
+			if (connection != null) {
+				try {
+					connection.close();
+				} catch (SQLException e) {
+					// nothing to do
+				}
+			}
+		}
 	}
 
     private KEngine start() throws WebApplicationException {

--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoService.java
@@ -24,10 +24,12 @@ package org.komodo.rest;
 import static org.komodo.rest.Messages.Error.COMMIT_TIMEOUT;
 import static org.komodo.rest.Messages.Error.RESOURCE_NOT_FOUND;
 import static org.komodo.rest.Messages.General.GET_OPERATION_NAME;
+
 import java.io.StringWriter;
 import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -41,6 +43,7 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.Marshaller;
 import javax.xml.namespace.QName;
+
 import org.komodo.core.KEngine;
 import org.komodo.core.repository.RepositoryImpl;
 import org.komodo.core.repository.SynchronousCallback;
@@ -64,14 +67,13 @@ import org.komodo.spi.repository.Repository.UnitOfWorkListener;
 import org.komodo.utils.KLog;
 import org.komodo.utils.StringNameValidator;
 import org.komodo.utils.StringUtils;
+
 import com.google.gson.Gson;
 
 /**
  * A Komodo service implementation.
  */
 public abstract class KomodoService implements V1Constants {
-
-    public static final String KOMODO_USER = "anonymous";
 
     protected static final KLog LOGGER = KLog.getLogger();
 
@@ -197,27 +199,11 @@ public abstract class KomodoService implements V1Constants {
     }
 
     protected SecurityPrincipal checkSecurityContext(HttpHeaders headers) {
-    	return new SecurityPrincipal(KOMODO_USER, null);
-    	/*
-        try {
-            if (securityContext == null)
-                throw new Exception("No security context available");
-
-            if (!securityContext.isSecure())
-                throw new Exception("Access to REST service should ONLY be via a secure channel");
-
-            Principal userPrincipal = securityContext.getUserPrincipal();
-            if (userPrincipal == null)
-                throw new Exception("No user associated with request");
-
-            return new SecurityPrincipal(userPrincipal.getName(), null);
-        } catch (Exception ex) {
-            return new SecurityPrincipal(null, 
-                                         createErrorResponse(Status.UNAUTHORIZED,
-                                                                                 headers.getAcceptableMediaTypes(),
-                                                                                 ex, SECURITY_FAILURE_ERROR));
-        }
-        */
+    	if (AuthHandlingFilter.threadOAuthCredentials.get() != null) {
+    		return new SecurityPrincipal(AuthHandlingFilter.threadOAuthCredentials.get().getUser(), null);	
+    	}
+		return new SecurityPrincipal(null, createErrorResponse(Status.UNAUTHORIZED,
+				headers.getAcceptableMediaTypes(), RelationalMessages.Error.SECURITY_FAILURE_ERROR));
     }
 
     /**

--- a/server/komodo-rest/src/main/java/org/komodo/rest/TeiidSwarmMetadataInstance.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/TeiidSwarmMetadataInstance.java
@@ -21,12 +21,308 @@
  */
 package org.komodo.rest;
 
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeMap;
+
 import org.komodo.metadata.DefaultMetadataInstance;
 import org.komodo.metadata.TeiidConnectionProvider;
+import org.komodo.spi.KException;
+import org.komodo.spi.runtime.ServiceCatalogDataSource;
+import org.komodo.utils.KLog;
+import org.teiid.adminapi.AdminException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.kubernetes.client.LocalObjectReference;
+import io.kubernetes.client.ModelServiceCatalogClient;
+import io.kubernetes.client.ParametersFromSource;
+import io.kubernetes.client.Secret;
+import io.kubernetes.client.ServiceBinding;
+import io.kubernetes.client.ServiceBindingList;
+import io.kubernetes.client.ServiceInstance;
+import io.kubernetes.client.ServiceInstanceList;
 
 public class TeiidSwarmMetadataInstance extends DefaultMetadataInstance {
 
+	private static final String OSURL = "https://openshift.default.svc";
+	private static final String SC_VERSION = "v1beta1";
+	private ModelServiceCatalogClient scClient;
+	private enum SourceType {postgresql, mysql, mongodb, salesforce};
+	
     public TeiidSwarmMetadataInstance(TeiidConnectionProvider connectionProvider) {
 		super(connectionProvider);
+		this.scClient = new ModelServiceCatalogClient(OSURL, SC_VERSION);
+	}
+    
+	@Override
+	public Set<ServiceCatalogDataSource> getServiceCatalogSources() throws KException {
+    	String token = AuthHandlingFilter.threadOAuthCredentials.get().getToken();
+    	this.scClient.setAuthHeader(token);
+    	Set<ServiceCatalogDataSource> sources = new HashSet<>();
+    	try {
+			ServiceInstanceList serviceList = this.scClient.getServiceInstances(ApplicationProperties.getNamespace());
+			List<ServiceInstance> services = serviceList.getItems();
+			if( services != null && !services.isEmpty()) {
+				for (ServiceInstance svc : services) {
+					if (svc.getStatus().isReady()) {
+						Map<String, String> parameters = getParameters(svc);
+						SourceType type = matchType(svc, parameters);
+						if (type != null) {
+							ServiceCatalogDataSourceImpl scd = new ServiceCatalogDataSourceImpl();
+							scd.setName(svc.getMetadata().getName());
+							scd.setType(type.name());
+							ServiceBinding binding = getServiceBinding(svc);
+							if (binding == null) {
+								scd.setBound(true);
+							}
+							sources.add(scd);
+						}
+					}
+				}
+			}
+    	} catch (Exception e) {
+    		throw handleError(e);
+    	}
+    	return sources;
+	}
+
+	private SourceType matchType(ServiceInstance svc, Map<String, String> parameters) {
+		if (parameters.get("POSTGRESQL_DATABASE") != null) {
+			return SourceType.postgresql;
+		} else if (parameters.get("MYSQL_DATABASE") != null) {
+			return SourceType.mysql;
+		} else if (parameters.get("MONGODB_DATABASE") != null) {
+			return SourceType.mongodb;
+		}
+		return null;
+	}
+
+	@Override
+	public void bindToServiceCatalogSource(String dsName) throws KException {
+		KLog.getLogger().info("Bind to Service" + dsName);
+		String token = AuthHandlingFilter.threadOAuthCredentials.get().getToken();
+		this.scClient.setAuthHeader(token);
+		try {
+			ServiceInstance svc = this.scClient.getServiceInstance(ApplicationProperties.getNamespace(), dsName);
+			if (svc == null) {
+				throw new KException("No Service Catalog Service found with name " + dsName);
+			}
+			
+			ServiceBinding binding = getServiceBinding(svc);
+			if (binding != null) {
+				KLog.getLogger().debug("Found existing Binding = " + binding);
+			}
+			if (binding == null) {
+				binding = this.scClient.createServiceBinding(svc);
+				KLog.getLogger().debug("Created new Binding = " + binding);
+			}
+			
+			//TODO: need to come up async based operation
+			int i = 0;
+			while(!binding.getStatus().isReady()) {
+				Thread.sleep(5000);
+				i++;
+				binding = getServiceBinding(svc);
+				if (i > 3 || binding == null) {
+					throw new KException("Created Service Binding is not Ready");
+				}
+			}
+			
+			Map<String, String> parameters = getParameters(svc);
+			SourceType type = matchType(svc, parameters);
+			
+			Collection<String> dsNames = admin().getDataSourceNames();
+			if (!dsNames.contains(dsName)) {				
+				Map<String, String> bindingSecrets = getBindingSecrets(binding);
+				bindingSecrets.putAll(parameters);
+				createDataSource(dsName, type, bindingSecrets);				
+			}			
+		} catch (Exception e) {
+			throw handleError(e);
+		}
+	}    
+    
+	private Map<String, String> getBindingSecrets(ServiceBinding binding) throws IOException {
+		Map<String, String> map = new TreeMap<>();
+		if (binding != null) {
+			String secretName = binding.getSpec().getSecretName();
+			Secret secret = this.scClient.getSecret(ApplicationProperties.getNamespace(), secretName);
+			map = secret.getData();
+			Map<String, String> decodedMap = new TreeMap<>();
+			if (map != null && !map.isEmpty()) {
+				for (Map.Entry<String, String> entry:map.entrySet()) {
+					String key = entry.getKey();
+					String encodedValue = entry.getValue();
+					decodedMap.put(key, new String(Base64.getDecoder().decode(encodedValue)));
+				}
+			}
+			map = decodedMap;
+		}
+		return map;
+	}
+
+	private ServiceBinding getServiceBinding(ServiceInstance svc) throws IOException {
+    	ServiceBindingList bindingList = this.scClient.getServiceBindings(ApplicationProperties.getNamespace());
+		List<ServiceBinding> bindings = bindingList.getItems();
+		if( bindings != null && !bindings.isEmpty()) {
+			for (ServiceBinding sb : bindings) {
+				LocalObjectReference ref = sb.getSpec().getServiceInstanceRef();
+				if (ref.getName().equals(svc.getMetadata().getName())) {
+					return sb;
+				}
+			}
+		}
+    	return null;
+    }
+    
+    private Map<String, String> getParameters(ServiceInstance svc) throws IOException {
+    	Map<String, String> map = new TreeMap<>();
+    	
+		// data source is there.
+		ParametersFromSource parameters = null;
+		for (int i = 0; i < svc.getSpec().getParametersFrom().size(); i++) {
+			parameters = svc.getSpec().getParametersFrom().get(i);
+			if(parameters.getSecretKeyRef().getKey().equalsIgnoreCase("parameters")) {
+				break;
+			}
+		}
+		if (parameters != null) {
+			String secretName = parameters.getSecretKeyRef().getName();
+			String key = parameters.getSecretKeyRef().getKey();
+			Secret secret = this.scClient.getSecret(ApplicationProperties.getNamespace(),
+					secretName);
+			if (secret != null) {
+				String json = secret.getData().get(key);
+				map = new ObjectMapper().readerFor(Map.class).readValue(Base64.getDecoder().decode(json));					
+			}
+		} else {
+			KLog.getLogger().debug(svc.getMetadata().getName()+":No Parameters Secret found");
+		}  
+		return map;
+    }
+    
+	private void createDataSource(String name, SourceType type, Map<String, String> map) throws AdminException, KException {
+		KLog.getLogger().debug("Creating the Datasource = "+name + " with properties = "+map);
+		
+		String driverName = null;
+		Set<String> templateNames = admin().getDataSourceTemplateNames();
+		KLog.getLogger().debug("template names:"+templateNames);
+		for (String template : templateNames) {
+			// TODO: there is null entering from above call from getDataSourceTemplateNames need to investigate why
+			if (template != null && template.startsWith(type.name())) {
+				driverName = template;
+				break;
+			}
+		}
+		
+		if (driverName == null) {
+			throw new KException("No driver or resource adapter found for source type " + type);
+		}
+		
+		if (type.equals(SourceType.postgresql)) {
+			/*
+			 {
+			   "DATABASE_SERVICE_NAME":"postgresql",
+			   "MEMORY_LIMIT":"512Mi",
+			   "NAMESPACE":"openshift",
+			   "database_name":"sampledb",
+			   "password":"pass",
+			   "username":"user",
+			   "uri": "postgres://172.30.145.26:5432",
+			   "POSTGRESQL_VERSION":"9.5",
+			   "VOLUME_CAPACITY":"1Gi"
+			}
+			*/
+			Properties props = new Properties();
+			props.setProperty("connection-url", "jdbc:postgresql://" + map.get("DATABASE_SERVICE_NAME") + ":5432/"
+					+ map.get("database_name"));
+			props.setProperty("user-name", map.get("username"));
+			props.setProperty("password", map.get("password"));
+			admin().createDataSource(name, driverName, props);
+		} else if (type.equals(SourceType.mysql)) {
+			/*
+			{
+			  "DATABASE_SERVICE_NAME":"mariadb",
+			  "MEMORY_LIMIT":"512Mi",
+			  "MYSQL_DATABASE":"sampledb",
+			  "NAMESPACE":"openshift",
+			  "VOLUME_CAPACITY":"1Gi"
+			  database-password
+			  database-name
+			  database-root-password
+		      database-user
+			} 
+			 */
+			Properties props = new Properties();
+			props.setProperty("connection-url", "jdbc:mysql://"+map.get("DATABASE_SERVICE_NAME")+":3306/" 
+					+ map.get("database-name"));
+			props.setProperty("user-name", map.get("database-user"));
+			props.setProperty("password", map.get("database-password"));
+			admin().createDataSource(name, driverName, props);
+		} else if (type.equals(SourceType.mongodb)) {
+			/*
+			{
+				  "DATABASE_SERVICE_NAME":"mongodb",
+				  "MEMORY_LIMIT":"512Mi",
+				  "MONGODB_DATABASE":"sampledb",
+				  "MONGODB_VERSION":"3.2",
+				  "NAMESPACE":"openshift",
+				  "VOLUME_CAPACITY":"1Gi"
+				  database-password
+				  database-name
+				  database-admin-password
+			      database-user				  
+			}
+			*/
+			Properties props = new Properties();
+			props.setProperty("RemoteServerList", map.get("DATABASE_SERVICE_NAME")+":27017");
+			props.setProperty("Username", map.get("database-user"));
+			props.setProperty("Password", map.get("database-password"));
+			props.setProperty("Database", map.get("database-name"));
+			props.setProperty("SecurityType", "SCRAM_SHA_1");
+			props.setProperty("AuthDatabase", map.get("database-name"));
+			props.setProperty("Ssl", "false");
+			admin().createDataSource(name, driverName, props);
+		}
+	}
+    
+	static class ServiceCatalogDataSourceImpl implements ServiceCatalogDataSource {
+		private String name;
+		private String type;
+		private boolean bound;
+		
+		@Override
+		public String getName() {
+			return name;
+		}
+
+		@Override
+		public String getType() {
+			return type;
+		}
+
+		@Override
+		public boolean isBound() {
+			return bound;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public void setType(String type) {
+			this.type = type;
+		}
+
+		public void setBound(boolean bound) {
+			this.bound = bound;
+		}
 	}
 }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -225,7 +225,12 @@ public final class RelationalMessages {
         /**
          * Connection transfer to repo success
          */
-        CONNECTION_TO_REPO_SUCCESS;
+        CONNECTION_TO_REPO_SUCCESS,
+        
+        /**
+         * Bind operation with Service Catalog Data Source
+         */
+        METADATA_SERVICE_CATALOG_DATA_SERVIVE_BIND_TITLE;
 
         /**
          * {@inheritDoc}
@@ -1297,7 +1302,28 @@ public final class RelationalMessages {
         /**
          * An import export service storage types missing parameter error
          */
-        IMPORT_EXPORT_SERVICE_MISSING_PARAMETER_ERROR;
+        IMPORT_EXPORT_SERVICE_MISSING_PARAMETER_ERROR,
+        
+        /**
+         * An error indicating the failed status of to get a data services from service catalog
+         */
+        METADATA_SERVICE_CATALOG_GET_DATA_SOURCES_ERROR,
+        
+        /**
+         * An error indicating a name of data service missing from bind operation on service catalog service 
+         */
+        METADATA_SERVICE_CATALOG_DATA_SERVICE_BIND_MISSING_NAME,
+        
+        /**
+         * An error indicating payload parse error from bind operation on service catalog service 
+         */
+        METADATA_SERVICE_CATALOG_DATA_SERVICE_BIND_PARSE_ERROR,
+        
+        /**
+         * An error indicating from bind operation on service catalog service
+         */
+        METADATA_SERVICE_CATALOG_DATA_SERVIVE_BIND_ERROR;
+        
 
         /**
          * {@inheritDoc}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RestEntityFactory.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RestEntityFactory.java
@@ -50,6 +50,7 @@ import org.komodo.rest.KomodoRestV1Application.V1Constants;
 import org.komodo.rest.RestBasicEntity;
 import org.komodo.rest.relational.connection.RestConnection;
 import org.komodo.rest.relational.dataservice.RestDataservice;
+import org.komodo.rest.relational.response.RestServiceCatalogDataSource;
 import org.komodo.rest.relational.response.RestVdb;
 import org.komodo.rest.relational.response.RestVdbCondition;
 import org.komodo.rest.relational.response.RestVdbDataRole;
@@ -73,6 +74,7 @@ import org.komodo.spi.repository.KomodoType;
 import org.komodo.spi.repository.Repository;
 import org.komodo.spi.repository.Repository.UnitOfWork;
 import org.komodo.spi.repository.Repository.UnitOfWork.State;
+import org.komodo.spi.runtime.ServiceCatalogDataSource;
 import org.komodo.spi.runtime.TeiidDataSource;
 import org.komodo.spi.runtime.TeiidPropertyDefinition;
 import org.komodo.spi.runtime.TeiidTranslator;
@@ -346,4 +348,14 @@ public class RestEntityFactory implements V1Constants {
 
         return restEntries;
     }
+    
+	public RestServiceCatalogDataSource createServiceCatalogDataSource(UnitOfWork transaction, Repository repository,
+			ServiceCatalogDataSource datasource, URI baseUri) throws Exception {
+        checkTransaction(transaction);
+        ArgCheck.isTrue(transaction.isRollbackOnly(), "transaction should be rollback-only");
+        
+        // TODO:  phantomjinx what needs to be done here?
+        KomodoObject parent = createTemporaryParent(transaction, repository, null);
+        return new RestServiceCatalogDataSource(baseUri, parent, datasource, transaction);
+	}  
 }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/request/KomodoServiceCatalogDataSourceAttributes.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/request/KomodoServiceCatalogDataSourceAttributes.java
@@ -1,0 +1,108 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational.request;
+
+import javax.ws.rs.core.MediaType;
+
+import org.komodo.rest.KRestEntity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+
+/**
+ * Object to be serialised by GSON that encapsulates a connection object
+ */
+@JsonSerialize
+@JsonInclude(value=Include.NON_NULL)
+public class KomodoServiceCatalogDataSourceAttributes implements KRestEntity {
+
+	/**
+     * Label for the name
+     */
+    public static final String NAME_LABEL = "name"; //$NON-NLS-1$
+
+    @JsonProperty(NAME_LABEL)
+    private String name;
+
+
+    /**
+     * Default constructor for deserialization
+     */
+    public KomodoServiceCatalogDataSourceAttributes() {
+        // do nothing
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean supports(MediaType mediaType) {
+        return MediaType.APPLICATION_JSON_TYPE.equals(mediaType);
+    }
+
+    @Override
+    @JsonIgnore
+    public Object getXml() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return this.name;
+    }
+
+    /**
+     * @param name
+     */
+    public void setJndi(String name) {
+        this.name = name;
+    }
+
+    @Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		KomodoServiceCatalogDataSourceAttributes other = (KomodoServiceCatalogDataSourceAttributes) obj;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		return true;
+	}    
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/RestServiceCatalogDataSource.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/RestServiceCatalogDataSource.java
@@ -1,0 +1,108 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational.response;
+
+import java.net.URI;
+import java.util.Properties;
+
+import org.komodo.rest.KomodoService;
+import org.komodo.rest.RestBasicEntity;
+import org.komodo.rest.RestLink;
+import org.komodo.rest.RestLink.LinkType;
+import org.komodo.rest.relational.KomodoRestUriBuilder.SettingNames;
+import org.komodo.spi.KException;
+import org.komodo.spi.lexicon.servicecatalog.ServiceCatalogLexicon;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.spi.runtime.ServiceCatalogDataSource;
+import org.komodo.utils.ArgCheck;
+
+public class RestServiceCatalogDataSource extends RestBasicEntity implements ServiceCatalogDataSource {
+    /**
+     * Label used to describe name
+     */
+    public static final String NAME_LABEL = KomodoService.protectPrefix(ServiceCatalogLexicon.DataService.NAME);
+
+    /**
+     * Label used to describe type
+     */
+    public static final String TYPE_LABEL = KomodoService.protectPrefix(ServiceCatalogLexicon.DataService.TYPE);
+
+    /**
+     * Label used to describe bound 
+     */
+    public static final String BOUND_LABEL = KomodoService.protectPrefix(ServiceCatalogLexicon.DataService.BOUND);
+
+	public RestServiceCatalogDataSource(URI baseUri, KomodoObject parent, ServiceCatalogDataSource datasource,
+			UnitOfWork uow) throws KException {
+		super(baseUri, parent, uow);
+		
+        ArgCheck.isNotNull(datasource, "datasource"); //$NON-NLS-1$
+        ArgCheck.isNotNull(uow, "uow"); //$NON-NLS-1$
+
+        setId(datasource.getName());
+        setkType(KomodoType.SERVICE_CATALOG_DATA_SOURCE);
+        setHasChildren(false);
+        
+        setName(datasource.getName());
+        setType(datasource.getType());
+        setBound(datasource.isBound());
+
+        Properties settings = getUriBuilder().createSettings(SettingNames.CONNECTION_NAME, getId());
+        URI parentUri = getUriBuilder().mServerConnectionsUri();
+        getUriBuilder().addSetting(settings, SettingNames.PARENT_PATH, parentUri);
+
+        addLink(new RestLink(LinkType.SELF, getUriBuilder().connectionUri(LinkType.SELF, settings)));
+        addLink(new RestLink(LinkType.PARENT, getUriBuilder().connectionUri(LinkType.PARENT, settings)));		
+	}
+
+	@Override
+	public String getName() {
+        Object name = tuples.get(NAME_LABEL);
+        return name != null ? name.toString() : null;
+	}
+
+	@Override
+	public String getType() {
+        Object type = tuples.get(TYPE_LABEL);
+        return type != null ? type.toString() : null;
+	}
+
+	@Override
+	public boolean isBound() {
+		Object label = tuples.get(BOUND_LABEL);
+		return label != null ? Boolean.parseBoolean(label.toString()) : false;
+	}
+	
+	public void setName(String name) {
+		tuples.put(NAME_LABEL, name);		
+	}
+
+	public void setType(String type) {
+		tuples.put(TYPE_LABEL, type);
+	}
+
+	public void setBound(boolean bound) {
+		tuples.put(BOUND_LABEL, bound);
+	}	
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/swagger/RestServiceCatalogDataSourceConverter.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/swagger/RestServiceCatalogDataSourceConverter.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.swagger;
+
+import org.komodo.rest.relational.dataservice.RestDataservice;
+import org.komodo.rest.relational.response.RestServiceCatalogDataSource;
+import org.komodo.spi.repository.KomodoType;
+
+import io.swagger.converter.ModelConverterContext;
+import io.swagger.models.ModelImpl;
+
+/**
+ * Converter to display properties of {@link RestDataservice} class in swagger
+ */
+public class RestServiceCatalogDataSourceConverter extends RestEntityConverter<RestServiceCatalogDataSource> {
+
+    @Override
+    protected Class<RestServiceCatalogDataSource> getEntityClass() {
+        return RestServiceCatalogDataSource.class;
+    }
+
+    @Override
+    protected KomodoType getKomodoType() {
+        return KomodoType.SERVICE_CATALOG_DATA_SOURCE;
+    }
+
+    @Override
+    protected void addProperties(ModelImpl model, ModelConverterContext context) throws Exception {
+        model.property(RestServiceCatalogDataSource.NAME_LABEL, requiredProperty(String.class));
+        model.property(RestServiceCatalogDataSource.TYPE_LABEL, property(String.class));
+        model.property(RestServiceCatalogDataSource.BOUND_LABEL, property(Boolean.class));
+    }
+}

--- a/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -58,7 +58,8 @@ Info.CONNECTION_TO_REPO_STATUS_TITLE = Connection transfer to workspace Status
 Info.CONNECTION_TO_REPO_SUCCESS = Connection transfer to workspace was successful
 Info.CONNECTION_UNDEPLOYMENT_REQUEST_SENT = A request has been sent to delete the connection '%s'
 Info.CONNECTION_SUCCESSFULLY_UNDEPLOYED = The connection '%s' has been undeployed
- 
+Info.METADATA_SERVICE_CATALOG_DATA_SERVIVE_BIND_TITLE=Bind Operation for Service Catalog Data Source %s
+
 Error.SECURITY_FAILURE_ERROR = An error occurred when trying to authenticate and authorize use of the REST service: %s
 Error.VDB_DATA_SOURCE_NAME_EXISTS = A VDB must have a different name than an existing data source.
 Error.VDB_NAME_EXISTS = A VDB with the same name already exists.
@@ -277,4 +278,7 @@ Error.IMPORT_EXPORT_SERVICE_IMPORT_ERROR = An error occurred while attempting to
 Error.IMPORT_EXPORT_SERVICE_STORAGE_TYPES_ERROR = An error occurred while attempting to retrieve the available import/export storage types: %s
 Error.IMPORT_EXPORT_SERVICE_MISSING_PARAMETER_ERROR = The parameter %s is required for the import/export operation but was not specified in the operation call
 Error.IMPORT_EXPORT_SERVICE_IMPORT_ARTIFACT_ERROR = An error occurred while attempting to perform the import: %s
-
+Error.METADATA_SERVICE_CATALOG_GET_DATA_SOURCES_ERROR= An error occurred while attempting to read data services from service catalog
+Error.METADATA_SERVICE_CATALOG_DATA_SERVICE_BIND_MISSING_NAME=The payload is missing name of the service catalog data service
+Error.METADATA_SERVICE_CATALOG_DATA_SERVICE_BIND_PARSE_ERROR=An error occurred while trying to parse payload for bind operation on service catalog data service
+Error.METADATA_SERVICE_CATALOG_DATA_SERVIVE_BIND_ERROR=An error occurred during bind operation of the service catalog service %s 

--- a/server/komodo-rest/src/main/webapp/index.html
+++ b/server/komodo-rest/src/main/webapp/index.html
@@ -1,0 +1,8 @@
+<html>
+<title>Komodo Server</title>
+<body>
+	<h1>Komodo Server</h1>
+	<a href="api-docs">swagger-ui</a><p/>
+	<a href="v1/swagger.json">swagger.json</a>
+</body>
+</html>

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/integration/AbstractKomodoMetadataServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/integration/AbstractKomodoMetadataServiceTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.InputStream;
 import java.net.URI;
@@ -33,7 +34,9 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
 import javax.ws.rs.core.UriBuilder;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;

--- a/server/komodo-rest/src/test/resources/arquillian.xml
+++ b/server/komodo-rest/src/test/resources/arquillian.xml
@@ -6,7 +6,13 @@
 	<container qualifier="wildfly-swarm" default="true">
 		<configuration>
 			<property name="javaVmArguments">-Xmx2048m -Xms512m -XX:MaxPermSize=128m
-				-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n -DREPOSITORY_PERSISTENCE_TYPE=H2</property>
+				-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n -DREPOSITORY_PERSISTENCE_TYPE=H2
+                -Dkomodo.connectionDriver=org.h2.Driver 
+                -Dkomodo.connectionUrl=jdbc:h2:file:./target/komododb;AUTO_SERVER=TRUE 
+                -Dkomodo.binaryStoreUrl=jdbc:h2:file:./target/storage/content/binaries;DB_CLOSE_DELAY=-1 
+                -Dkomodo.user=komodo 
+                -Dkomodo.password=komodo
+        </property>
 		</configuration>
 	</container>
 </arquillian>


### PR DESCRIPTION
1) Upgraded Teiid version to 10.0.0.Final
2) Also upgraded the WF-Swarm to reflect the version of the Teiid.
3) Changed the maven group ids to reflect the new version
4) Added a dependency on https://github.com/teiid/kubernetes-service-catalog-client project, which is library required to interact with service catalog (this needs to put in maven central too)
5) Added code to create a docker image based on F8 docker plug-in. This is helpful in releasing a final image, which is tested with the template image at https://github.com/rareddy/osb-data-services This project will be merged with @shawkins work on community-based images. These would be community deliverables.
6) The above template uses oauth-proxy to let user login into OpenShift, which is a http proxy
7) Based on headers from the oauth-proxy in the Komodo a AuthProxy has been added to inject the access-token an user name into a known context that is accessible to rest of the modules. At a later point, we will consider building a full security context based on these.
8) Also added a PG image to the template, which can be used as storage for modeshape.
With all above in place, if there is a Posgresql database that has been provisioned to the project, a call to Komodo's rest api /v1/metadata/connections will contact the service broker and get list of services, and then, if required it will bind to the service (if not already bound), and will gather the properties required for to make connection from the OpenShift Secrets and using the Teiid's Admin API will create a connection, and then return the resulting connections available in the Komodo-Teiid engine.