### PR TITLE
Adds a MAVEN MIRROR URL variable to openshift build

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+#
+# Overridden version of wildfly-sti assemble script
+# https://github.com/wildfly-swarm-archive/sti-wildflyswarm/blob/master/1.0/s2i/bin/assemble
+#
+# Includes ability to set a MAVEN_MIRROR_URL to help build performance times
+#
+
+# restore maven dependencies downloaded in a previous build,
+# so they do not have to be downloaded again.
+# /opt/s2i/destination/artifacts will only be present in the incremental build scenario
+# in which the target image name is an existing docker image which contains
+# dependencies from a prior build execution.
+function restore_saved_artifacts() {
+  if [ "$(ls -A /opt/s2i/destination/artifacts/ 2>/dev/null)" ]; then
+    echo -n "Restoring saved artifacts from prior build..."
+    mv /opt/s2i/destination/artifacts/.m2 $HOME/.m2
+  fi
+}
+
+# Source code provided to S2I is at ${HOME}
+LOCAL_SOURCE_DIR=${HOME}
+mkdir -p $LOCAL_SOURCE_DIR
+
+# Copy the source for compilation
+cp -Rf /opt/s2i/destination/src/. $LOCAL_SOURCE_DIR
+chgrp -R 0 $LOCAL_SOURCE_DIR
+chmod -R g+rw $LOCAL_SOURCE_DIR
+
+# If a pom.xml is present, this is a normal build scenario
+# so run maven.
+if [ -f "$LOCAL_SOURCE_DIR/pom.xml" ]; then
+  # restore any maven dependencies which will be present if this is an
+  # incremental build
+  restore_saved_artifacts
+
+  pushd $LOCAL_SOURCE_DIR &> /dev/null
+
+  # add maven mirror
+  if [ -n "$MAVEN_MIRROR_URL" ]; then
+    echo "The MAVEN_MIRROR_URL enivonment variable is defined so inserting it as a mirror to ${LOCAL_SOURCE_DIR}/settings.xml"
+    sed -i -e 's/<mirrors>/&\n    <mirror>\n      <id>sti-mirror<\/id>\n      <url>${MAVEN_MIRROR_URL}<\/url>\n      <mirrorOf>external:*<\/mirrorOf>\n    <\/mirror>/' ${LOCAL_SOURCE_DIR}/settings.xml
+  else
+    echo "The MAVEN_MIRROR_URL environment variable not defined so dependencies to be downloaded directly"
+  fi
+
+  if [ -z "$MAVEN_ARGS" ]; then
+    export MAVEN_ARGS="-U install -Popenshift -DskipTests"
+  fi
+  if [ -z "$MAVEN_ARGS_APPEND" ]; then
+    export MAVEN_ARGS="$MAVEN_ARGS $MAVEN_ARGS_APPEND"
+  fi
+  echo "Found pom.xml... attempting to build with 'mvn ${MAVEN_ARGS}'"
+
+  mvn --version
+  mvn $MAVEN_ARGS
+
+  ERR=$?
+  if [ $ERR -ne 0 ]; then
+    echo "Aborting due to error code $ERR from mvn package"
+    exit $ERR
+  fi
+
+  popd &> /dev/null
+
+else
+  echo "Oops - only maven builds are supported for now."
+  exit 1
+fi
+
+echo "...done"

--- a/komodo-openshift/scripts/komodo-os-setup.sh
+++ b/komodo-openshift/scripts/komodo-os-setup.sh
@@ -19,6 +19,8 @@
 function show_help {
 	echo "Usage: $0 -h [-r]"
 	echo "-h ip|hostname: location of Openshift host"
+	echo "-m url: maven mirror url"
+	echo "-s url: source repository location url"
 	echo "-r local mvn repo: provides an additional nexus repository"
   exit 1
 }
@@ -36,11 +38,13 @@ fi
 #
 # Determine the command line options
 #
-while getopts "h:r:" opt;
+while getopts "h:m:r:s:" opt;
 do
 	case $opt in
 	h) OS_HOST=$OPTARG ;;
+	m) MVN_MIRROR=$OPTARG ;;
 	r) LOCAL_MVN_REPO=$OPTARG ;;
+	s) SOURCE_REPO=$OPTARG ;;
 	*) show_help ;;
 	esac
 done
@@ -64,9 +68,17 @@ echo -e '\n\n=== Creating the template. ==='
 oc get template ${OS_TEMPLATE} 2>&1 > /dev/null || \
 	oc create -f ${OS_TEMPLATE}.json || \
 	{ echo "FAILED: Could not create application template" && exit 1; }
+
+if [ -n "MVN_MIRROR" ]; then
+  APP_ARGS="${APP_ARGS} --param=MVN_MIRROR_URL=${MVN_MIRROR}"
+fi
                       
 if [ -n "LOCAL_MVN_REPO" ]; then
   APP_ARGS="${APP_ARGS} --param=MVN_LOCAL_REPO=${LOCAL_MVN_REPO}"
+fi
+
+if [ -n "SOURCE_REPO" ]; then
+  APP_ARGS="${APP_ARGS} --param=KOMODO_GIT_URL=${SOURCE_REPO}"
 fi
   
 echo -e "\n\n=== Deploying ${OS_TEMPLATE} template with default values ==="

--- a/komodo-openshift/scripts/komodo-teiid-wildfly-swarm-s2i.json
+++ b/komodo-openshift/scripts/komodo-teiid-wildfly-swarm-s2i.json
@@ -16,6 +16,13 @@
     },
     "parameters": [
         {
+            "description": "The location url of the komodo source repository",
+            "displayName": "Komodo Source URL",
+            "name": "KOMODO_GIT_URL",
+            "value": "git://github.com/teiid/teiid-komodo.git",
+            "required": false
+        },
+        {
             "description": "Specify a custom hostname for the http route.  Leave blank to use default hostname, e.g.: <service-name>-<project>.<default-domain-suffix>",
             "displayName": "Custom http Route Hostname",
             "name": "HOSTNAME_HTTP",
@@ -48,6 +55,12 @@
             "displayName": "Additional maven repository",
             "name": "MVN_LOCAL_REPO",
             "value": "https://repository.jboss.org/nexus/content/repositories/central/",
+            "required": false
+        },
+        {
+            "description": "Maven Mirror Url for finding dependencies",
+            "displayName": "Maven Mirror Url",
+            "name": "MVN_MIRROR_URL",
             "required": false
         }
     ],
@@ -239,7 +252,7 @@
                 "source" : {
                     "type" : "Git",
                     "git" : {
-                        "uri": "git://github.com/teiid/teiid-komodo.git"
+                        "uri": "${KOMODO_GIT_URL}"
                     },
                     "contextDir": "."
                 },
@@ -252,6 +265,10 @@
                         },
                         "incremental": true,
                         "env": [
+                            {
+                               "name": "MAVEN_MIRROR_URL",
+                               "value": "${MVN_MIRROR_URL}"
+                            },
                             {
                                "name": "MAVEN_ARGS",
                                "value": "clean install -s settings.xml -Popenshift_s2i -Dlocal-repo=${MVN_LOCAL_REPO} -DskipTests -Dintegration.skipTests -B -pl org.teiid.komodo:komodo-rest,org.teiid.komodo:komodo-openshift -am"

--- a/settings.xml
+++ b/settings.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <settings>
+
+	<!-- Add a mirror here if required. Do not remove these tags since they are required placeholders for openshift -->
+	<mirrors>
+	</mirrors>
+
 	<profiles>
 		<!-- Redefine the Maven central repository to enable snapshots. The url 
 			will be replaced by the mirror -->


### PR DESCRIPTION
* To improve incremental build performance, the maven dependency repos can
  be mirrored locally using nexus (requires separate nexus server).

* Adds custom extended assemble script which reads the MAVEN_MIRROR URL
  and if defined adds it to the komodo settings.xml as a mirror

* settings.xml
 * Provides empty mirrors tags for placeholder

* komodo*.json
 * Adds MIRROR URL env variable to template
 * Refactors komodo git url as env variable so it can be overridden

* komodo*.sh
 * Exposes the MIRROR URL and SOURCE REPO as parameters to the script