### PR TITLE
Integrate OAuth proxy into development template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,71 @@
-# teiid-komodo
+teiid-komodo
+============
+
+## Building teiid-komodo locally
+- Install JDK 1.8 or higher;
+- Install [maven 3.2+](http://maven.apache.org/download.html);
+- By default, building will try to construct a docker image so a running Docker daemon is required. To skip this use the 'skip-docker' switch of the build script;
+- Clone the repository and execute the '**build.sh**' script.
+
+### Optional switches to build script
+* -d: enable maven debugging (adds -e -X -U);
+* -h: show the script help;
+* -s: skip unit test execution;
+* -q: enable integration test execution;
+* -z: skip docker image creation and deployment.
+
+## Running teiid-komodo on [Openshift](https://www.openshift.org)
+
+There are two methods available for running teiid-komodo.
+
+### Using the locally-built image
+Build teiid-komodo locally then once built, the docker image and Dockerfile will be available in 'server/komodo-rest/target/docker'. It should also have been registered in the local docker registry.
+
+An Openshift template that utilises this image is available [here](https://github.com/rareddy/osb-data-services/blob/master/komodo/data-access-service.json). This should be download and loaded into Openshift, inc. [minishift](https://github.com/minishift/minishift).
+
+
+
+### Building inside Openshift
+An alternative template is available at [komodo-openshift/scripts/komodo-teiid-wildfly-swarm-s2i.json](https://github.com/teiid/teiid-komodo/blob/master/komodo-openshift/scripts/komodo-teiid-wildfly-swarm-s2i.json). This template makes use of Openshift's s2i feature to build and then deploy teiid-komodo.
+
+A unix command-line [script](https://github.com/teiid/teiid-komodo/blob/master/komodo-openshift/scripts/komodo-os-setup.sh) is provided to ingest the template and its dependencies into a default project named 'vdb-builder'. The script requires an url (using the -h switch) that points to the Openshift instance (whether Openshift, minishift), eg.
+
+> ./komodo-os-setup.sh -h 192.168.88.5
+
+The result of instantiating the template will be the following pods:
+
+* wildfly-swarm-build-1-build - teiid-komodo is implemented on wildfly swarm hence requires this dependency build;
+* vdb-builder-build-1-build - an s2i build of teiid-komodo;
+* vdb-builder-1-xxxxx - a fully running implementation of teiid-komodo, a.k.a. vdb-builder (will only appear if the build completed);
+* vdb-builder-gateway-xxxxxxxx-xxxx - the external interface allowing access to teiid-komodo via https (port 8443);
+* vdb-builder-persistence-1-xxxxx - the database instance that provides the persistence store for teiid-komodo;
+
+Routes are provided for accessing vdb-builder's external interfaces.
+
+* https://vdb-builder-gateway-vdb-builder.xxx.xxx.xxx.xxx.nip.io/ provides a default landing page;
+* https://vdb-builder-gateway-vdb-builder.xxx.xxx.xxx.xxx.nip.io/vdb-builder/api-docs/ provides a [Swagger](https://swagger.io/) document of teiid-komodo's REST API;
+* https://vdb-builder-gateway-vdb-builder.xxx.xxx.xxx.xxx.nip.io/vdb-builder/v1/swagger.json provides a json document of the teiid-komodo REST API.
+
+#### Additional Options
+The *komodo-os-setup.sh* provides some additional options for building and deployment of teiid-komodo:
+* -m url: To improve building performance it is possible to specify a maven mirror url, which will be used for fetching all maven dependencies from. Installation of nexus on a local network host can facilitate far faster build-times as it effectively caches all the dependencies;
+-s url: The source repository, by default, is (https://github.com/teiid/teiid-komodo). Should an alternative be required, eg. a fork to test new functionality, then this can be specified and new builds will use that instead;
+-r local mvn repo: An additional maven repository can be specified that can be checked for maven dependencies. This is useful, for example, if custom / snapshot builds of dependencies are required that have not yet been pushed to a public maven repository.
+
+#### Troubleshooting
+
+##### DNS Resolution in Minishift
+A Minishift VM creates its own network adapter for connecting to the host OS which in turn allows full network connectivity. Resolving of DNS hostnames is performed using the same system. Sometimes it is possible for the Minishift instance to be started without full DNS resolution being available. In this case, hostnames, such as 'archive.apache.org', fail to resolve causing the s2i build of teiid-komodo to fail. Restarting the minishift instance can rectify this.
+
+##### Hostname 
+In Minishift, the VM is unable to see hostnames documented in the host OS' /etc/hosts file yet it is possible to resolve IP addresses. Only if the hostnames are inserted in the VM's own /etc/hosts will they be resolved correctly.
+
+##### Openshift Storage Space
+Openshift and Docker are responsible for generating a significant amount of content which can fill up HDD space, including docker images and persistent volumes. If space becomes too low then errors can start to appear. Cleaning up docker images in Minishift can require secure-shell into the VM then manually deleting the images using the native docker commands. Likewise, persistent volumes can require manually deletion of their directories.
+
+##### Memory and Storage Capacity Variables
+By default, Minishift starts with 2GB of memory and 20GB of storage. This can quickly prove insufficient for developing teiid-komodo. It is advisable to increase these values, eg.
+
+> minishift config set disk-size 60GB
+
+> minishift config set memory 6GB

--- a/build.sh
+++ b/build.sh
@@ -6,13 +6,15 @@
 #
 #################
 function show_help {
-	echo "Usage: $0 [-d] [-s] [-q] [-h]"
+	echo "Usage: $0 [-d] [-s] [-q] [-z] [-h]"
 	echo "-d - enable maven debugging"
+	echo "-h - show this help"
 	echo "-s - skip unit test execution"
 	echo "-q - execute integration test execution"
-  echo ""
-  echo "To passthrough additional arguments straight to maven, enter '--' followed by the extra arguments"
-  exit 1
+	echo "-z - skip docker image creation and deployment"
+	echo ""
+	echo "To passthrough additional arguments straight to maven, enter '--' followed by the extra arguments"
+	exit 1
 }
 
 #
@@ -49,13 +51,14 @@ DEBUG=0
 #
 # Determine the command line options
 #
-while getopts ":dhsq" opt;
+while getopts ":dhsqz" opt;
 do
   case $opt in
     d) DEBUG=1 ;;
     h) show_help ;;
     s) SKIP=1 ;;
     q) INT_TEST=1 ;;
+    z) NO_DOCKER=1 ;;
   esac
 done
 shift "$(expr $OPTIND - 1)"
@@ -85,6 +88,7 @@ MVN="mvn clean install"
 # Turn on dedugging if required
 #
 if [ "${DEBUG}" == "1" ]; then
+  echo "** Adding debugging maven parameters **"
   MVN_FLAGS="-e -X -U"
 fi
 
@@ -92,14 +96,20 @@ fi
 # Skip tests
 #
 if [ "${SKIP}" == "1" ]; then
+  echo "** Skipping all unit testing **"
   SKIP_FLAG="-DskipTests"
 fi
 
 if [ "${INT_TEST}" == "1" ]; then
+  echo "** Execution of integration tests enabled **" 
   INTEGRATION_TEST_FLAG="-Parquillian"
 fi
 
 DOCKER_RELEASE="-Pdocker-release"
+if [ "${NO_DOCKER}" == "1" ]; then
+  echo "** Skipping docker image build and local registration using docker-release profile **"
+  DOCKER_RELEASE=""
+fi
 
 #
 # Maven options

--- a/komodo-openshift/scripts/komodo-teiid-wildfly-swarm-s2i.json
+++ b/komodo-openshift/scripts/komodo-teiid-wildfly-swarm-s2i.json
@@ -66,6 +66,16 @@
     ],
     "objects": [
         {
+            "apiVersion":"v1",
+            "kind":"ServiceAccount",
+            "metadata": {
+                "name":"vdb-builder-gateway",
+                "annotations": {
+                    "serviceaccounts.openshift.io/oauth-redirectreference.primary":"{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"vdb-builder-gateway\"}}"
+                }
+            }
+        },
+        {
             "kind": "Service",
             "apiVersion": "v1",
             "metadata": {
@@ -89,6 +99,28 @@
                 ],
                 "selector": {
                     "name": "vdb-builder-persistence"
+                }
+            }
+        },
+        {
+            "apiVersion":"v1",
+            "kind":"Service",
+            "metadata": {
+                "name":"vdb-builder-gateway",
+                "annotations": {
+                    "service.alpha.openshift.io/serving-cert-secret-name":"proxy-tls"
+                }
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "name":"vdb-builder-gateway",
+                        "port": 443,
+                        "targetPort": 8443
+                    }
+                ],
+                "selector": {
+                    "app":"vdb-builder-gateway"
                 }
             }
         },
@@ -123,7 +155,28 @@
                     "application": "vdb-builder"
                 },
                 "annotations": {
-                    "description": "Designing data virtualization services."
+                    "description": "Designing data virtualization services.",
+                    "service.alpha.openshift.io/dependencies":"[{\"name\": \"vdb-builder-persistence\", \"kind\": \"Service\"}]"
+                }
+            }
+        },
+        {
+            "apiVersion":"v1",
+            "kind":"Route",
+            "metadata": {
+                "name":"vdb-builder-gateway"
+            },
+            "spec": {
+                "path": "/vdb-builder",
+                "port": {
+                    "targetPort": 8443
+                },
+                "to": {
+                    "name":"vdb-builder-gateway",
+                    "kind":"Service"
+                },
+                "tls": {
+                    "termination":"Reencrypt"
                 }
             }
         },
@@ -460,6 +513,7 @@
                         }
                     },
                     "spec": {
+                        "serviceAccountName":"vdb-builder-gateway",
                         "terminationGracePeriodSeconds": 60,
                         "containers": [
                             {
@@ -514,6 +568,76 @@
                                         "value": "${HOSTNAME_HTTP}"
                                     }
                                 ]
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion":"extensions/v1beta1",
+            "kind":"Deployment",
+            "metadata": {
+                "name":"vdb-builder-gateway"
+            },
+            "spec": {
+                "replicas":1,
+                "selector": {
+                    "matchLabels": {
+                        "app":"vdb-builder-gateway"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "app":"vdb-builder-gateway"
+                        }
+                    },
+                    "spec": {
+                        "serviceAccountName":"vdb-builder-gateway",
+                        "containers": [
+                            {
+                                "name":"oauth-proxy",
+                                "image":"openshift/oauth-proxy:v1.0.0",
+                                "imagePullPolicy":"IfNotPresent",
+                                "ports": [
+                                    {
+                                        "containerPort":8443,
+                                        "name":"public"
+                                    }
+                                ],
+                                "args": [
+                                    "--https-address=:8443",
+                                    "--provider=openshift",
+                                    "--openshift-service-account=vdb-builder-gateway",
+                                    "--upstream=http://vdb-builder:8080/vdb-builder/",
+                                    "--tls-cert=/etc/tls/private/tls.crt",
+                                    "--tls-key=/etc/tls/private/tls.key",
+                                    "--cookie-secret=V2lsZDAwZDJXaWxkMDBkMg==",
+                                    "--pass-access-token=true",
+                                    "--skip-provider-button=true",
+                                    "--pass-basic-auth=true",
+                                    "--pass-user-headers=true",
+                                    "--pass-host-header=true",
+                                    "--skip-auth-preflight",
+                                    "--openshift-ca=/etc/pki/tls/certs/ca-bundle.crt",
+                                    "--openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+                                    "--scope=user:info user:check-access role:admin:vdb-builder:! role:cluster-admin:vdb-builder:!"
+                                ],
+                                "volumeMounts": [
+                                    {
+                                        "mountPath":"/etc/tls/private",
+                                        "name":"proxy-tls"
+                                    }
+                                ]
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name":"proxy-tls",
+                                "secret": {
+                                    "secretName":"proxy-tls"
+                                }
                             }
                         ]
                     }

--- a/server/komodo-rest/src/main/webapp/index.html
+++ b/server/komodo-rest/src/main/webapp/index.html
@@ -22,7 +22,7 @@
 		</div>
 		<div class="row">
 			<div class="col-sm-6 col-md-6 col-lg-6 vdb-builder-link-cell">
-				<a class="vdb-builder-link" href="api-docs">Rest API Documentation</a>
+				<a class="vdb-builder-link" href="api-docs/">Rest API Documentation</a>
 			</div>
 			<div class="col-sm-6 col-md-6 col-lg-6 vdb-builder-link-cell">
 				<a class="vdb-builder-link" href="v1/swagger.json">API Json Specification</a>


### PR DESCRIPTION
* This is necessary since no komodo REST API functions can be initiated
  from this template without it, ie. even service/about fails without it

* Renames proxy to vdb-builder-gateway

* index.html
 * Corrects relative link to api-docs