### PR TITLE
Dataservice multi-view support

### DIFF
--- a/komodo-relational/src/main/java/org/komodo/relational/dataservice/Dataservice.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/dataservice/Dataservice.java
@@ -181,11 +181,11 @@ public interface Dataservice extends Exportable, RelationalObject, VdbEntryConta
      * @param uow
      *        the transaction (cannot be <code>null</code> or have a state that is not
      *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
-     * @return the name of the dataservice view (may be <code>null</code> if not found)
+     * @return the names of the dataservice views (may be empty if not found)
      * @throws KException
      *         if an error occurs
      */
-    String getServiceViewName( UnitOfWork uow ) throws KException;
+    String[] getServiceViewNames( UnitOfWork uow ) throws KException;
 
     /**
      * @param uow

--- a/komodo-relational/src/main/java/org/komodo/relational/dataservice/internal/DataserviceImpl.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/dataservice/internal/DataserviceImpl.java
@@ -488,8 +488,8 @@ public class DataserviceImpl extends RelationalObjectImpl implements Dataservice
      * @see org.komodo.relational.dataservice.Dataservice#getDataserviceView(org.komodo.spi.repository.Repository.UnitOfWork)
      */
     @Override
-    public String getServiceViewName(UnitOfWork uow) throws KException {
-        String viewName = null;
+    public String[] getServiceViewNames(UnitOfWork uow) throws KException {
+        List<String> viewNames = new ArrayList<String>();
         // Only ONE virtual model should exist in the dataservice vdb.
         // The returned view name is the first view in the first virtual model found - or null if none found.
         Vdb serviceVdb = getServiceVdb(uow);
@@ -500,13 +500,12 @@ public class DataserviceImpl extends RelationalObjectImpl implements Dataservice
                 if(modelType == Type.VIRTUAL) {
                     View[] views = model.getViews(uow);
                     for(View view : views) {
-                        viewName = view.getName(uow);
-                        break;
+                        viewNames.add(view.getName(uow));
                     }
                 }
             }
         }
-        return viewName;
+        return viewNames.toArray(new String[0]);
     }
 
     /* (non-Javadoc)

--- a/komodo-relational/src/test/java/org/komodo/relational/dataservice/internal/DataserviceImplTest.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/dataservice/internal/DataserviceImplTest.java
@@ -580,8 +580,13 @@ public final class DataserviceImplTest extends RelationalModelTest {
         virtualModel.setModelType( getTransaction(), Model.Type.VIRTUAL );
 
         // Add a view to the virtual model
-        final String serviceView = "serviceView";
-        virtualModel.addView( getTransaction(), serviceView );
+        final String serviceView1 = "serviceView1";
+        final String serviceView2 = "serviceView2";
+        virtualModel.addView( getTransaction(), serviceView1 );
+        virtualModel.addView( getTransaction(), serviceView2 );
+        final String[] serviceViews = new String[2];
+        serviceViews[0] = serviceView1;
+        serviceViews[1] = serviceView2;
 
         commit(); // need this so that VDB will be found by query that sets reference
 
@@ -592,7 +597,7 @@ public final class DataserviceImplTest extends RelationalModelTest {
         assertThat( this.dataservice.getServiceVdbEntry( getTransaction() ).getName( getTransaction() ), is( name ) );
         assertThat( this.dataservice.getServiceVdb( getTransaction() ), is( notNullValue() ) );
         assertThat( this.dataservice.getServiceViewModelName( getTransaction() ), is( serviceViewModel ) );
-        assertThat( this.dataservice.getServiceViewName( getTransaction() ), is( serviceView ) );
+        assertThat( this.dataservice.getServiceViewNames( getTransaction() ), is( serviceViews ) );
     }
 
     @Test

--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
@@ -303,9 +303,9 @@ public class KomodoRestV1Application extends Application implements SystemConsta
         String TEMPLATE_ENTRY_PLACEHOLDER = "{templateEntryName}"; //$NON-NLS-1$
 
         /**
-         * The name of the URI path segment for a setting a dataservice's service vdb for single table view
+         * The name of the URI path segment for a setting a dataservice's service vdb for single source table views
          */
-        String SERVICE_VDB_FOR_SINGLE_TABLE = "ServiceVdbForSingleTable"; //$NON-NLS-1$
+        String SERVICE_VDB_FOR_SINGLE_SOURCE_TABLES = "ServiceVdbForSingleSourceTables"; //$NON-NLS-1$
 
         /**
          * The name of the URI path segment for a setting a dataservice's service vdb for join view

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/dataservice/RestDataservice.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/dataservice/RestDataservice.java
@@ -57,9 +57,9 @@ public final class RestDataservice extends RestBasicEntity {
     public static final String DATASERVICE_VIEW_MODEL_LABEL = "serviceViewModel"; //$NON-NLS-1$
 
     /**
-     * Label used to describe dataservice viewName
+     * Label used to describe dataservice viewNames
      */
-    public static final String DATASERVICE_VIEW_LABEL = "serviceView"; //$NON-NLS-1$
+    public static final String DATASERVICE_VIEWS_LABEL = "serviceViews"; //$NON-NLS-1$
 
     /**
      * Label used to describe dataservice vdbName
@@ -119,7 +119,7 @@ public final class RestDataservice extends RestBasicEntity {
             setServiceVdbName(serviceVdb.getVdbName( uow ));
             setServiceVdbVersion(Integer.toString(serviceVdb.getVersion( uow )));
             setServiceViewModel(dataService.getServiceViewModelName(uow));
-            setServiceViewName(dataService.getServiceViewName(uow));
+            setServiceViewNames(dataService.getServiceViewNames(uow));
             
             // Get the current tables from source models
             List<String> tableNames = new ArrayList<String>();
@@ -183,16 +183,15 @@ public final class RestDataservice extends RestBasicEntity {
     /**
      * @return the service view name (can be empty)
      */
-    public String getServiceViewName() {
-        Object viewName = tuples.get(DATASERVICE_VIEW_LABEL);
-        return viewName != null ? viewName.toString() : null;
+    public String[] getServiceViewNames() {
+        return (String[])tuples.get(DATASERVICE_VIEWS_LABEL);
     }
 
     /**
-     * @param viewName the service view name to set
+     * @param viewNames the service view names to set
      */
-    public void setServiceViewName(String viewName) {
-        tuples.put(DATASERVICE_VIEW_LABEL, viewName);
+    public void setServiceViewNames(final String[] viewNames) {
+        tuples.put(DATASERVICE_VIEWS_LABEL, viewNames);
     }
 
     /**

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/DataserviceSingleSourceAttributesSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/DataserviceSingleSourceAttributesSerializer.java
@@ -1,0 +1,122 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational.json;
+
+import static org.komodo.rest.Messages.Error.UNEXPECTED_JSON_TOKEN;
+import static org.komodo.rest.relational.json.KomodoJsonMarshaller.BUILDER;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+import org.komodo.rest.Messages;
+import org.komodo.rest.relational.request.KomodoDataserviceSingleSourceAttributes;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * A GSON serializer/deserializer for {@status KomodoDataserviceSingleSourceAttribute}s.
+ */
+public final class DataserviceSingleSourceAttributesSerializer extends TypeAdapter< KomodoDataserviceSingleSourceAttributes > {
+
+    private static final Type STRING_LIST_TYPE = new TypeToken< List< String > >() {/* nothing to do */}.getType();
+    private static final Type MAP_LIST_TYPE = new TypeToken< Map<String,List<String>> >() {/* nothing to do */}.getType();
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see com.google.gson.TypeAdapter#read(com.google.gson.stream.JsonReader)
+     */
+    @Override
+    public KomodoDataserviceSingleSourceAttributes read( final JsonReader in ) throws IOException {
+        final KomodoDataserviceSingleSourceAttributes ssrcAttrs = new KomodoDataserviceSingleSourceAttributes();
+        in.beginObject();
+
+        while ( in.hasNext() ) {
+            final String name = in.nextName();
+
+            switch ( name ) {
+                case KomodoDataserviceSingleSourceAttributes.DATASERVICE_NAME_LABEL:
+                	ssrcAttrs.setDataserviceName(in.nextString());
+                    break;
+                case KomodoDataserviceSingleSourceAttributes.DATASERVICE_TABLE_PATHS_LABEL:
+                    List<String> tablePaths = BUILDER.fromJson(in, List.class);
+                	ssrcAttrs.setTablePaths(tablePaths);
+                    break;
+                case KomodoDataserviceSingleSourceAttributes.DATASERVICE_MODEL_SOURCE_PATH_LABEL:
+                	ssrcAttrs.setModelSourcePath(in.nextString());
+                    break;
+                case KomodoDataserviceSingleSourceAttributes.DATASERVICE_COLUMN_NAMES_LABEL:
+                    Map<String, List<String>> colNames = BUILDER.fromJson(in, Map.class);
+                    ssrcAttrs.setColumnNames(colNames);
+                    break;
+                case KomodoDataserviceSingleSourceAttributes.DATASERVICE_VIEW_DDL_LABEL:
+                	ssrcAttrs.setViewDdl(in.nextString());
+                    break;
+                default:
+                    throw new IOException( Messages.getString( UNEXPECTED_JSON_TOKEN, name ) );
+            }
+        }
+
+        in.endObject();
+
+        return ssrcAttrs;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see com.google.gson.TypeAdapter#write(com.google.gson.stream.JsonWriter, java.lang.Object)
+     */
+    @Override
+    public void write( final JsonWriter out,
+                       final KomodoDataserviceSingleSourceAttributes value ) throws IOException {
+
+        out.beginObject();
+
+        out.name(KomodoDataserviceSingleSourceAttributes.DATASERVICE_NAME_LABEL);
+        out.value(value.getDataserviceName());
+
+        if (! value.getTablePaths().isEmpty()) {
+            out.name(KomodoDataserviceSingleSourceAttributes.DATASERVICE_TABLE_PATHS_LABEL);
+            BUILDER.toJson(value.getTablePaths(), STRING_LIST_TYPE, out);
+        }
+
+        out.name(KomodoDataserviceSingleSourceAttributes.DATASERVICE_MODEL_SOURCE_PATH_LABEL);
+        out.value(value.getModelSourcePath());
+        
+        if (! value.getColumnNames().isEmpty()) {
+            out.name(KomodoDataserviceSingleSourceAttributes.DATASERVICE_COLUMN_NAMES_LABEL);
+            BUILDER.toJson(value.getColumnNames(), MAP_LIST_TYPE, out);
+        }
+
+        out.name(KomodoDataserviceSingleSourceAttributes.DATASERVICE_VIEW_DDL_LABEL);
+        out.value(value.getViewDdl());
+
+        out.endObject();
+    }
+
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/KomodoJsonMarshaller.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/KomodoJsonMarshaller.java
@@ -23,6 +23,7 @@ package org.komodo.rest.relational.json;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import org.komodo.rest.KRestEntity;
 import org.komodo.rest.RestBasicEntity;
 import org.komodo.rest.RestLink;
@@ -43,6 +44,7 @@ import org.komodo.rest.relational.json.connection.ConnectionSerializer;
 import org.komodo.rest.relational.json.connection.MetadataConnectionSerializer;
 import org.komodo.rest.relational.request.KomodoConnectionAttributes;
 import org.komodo.rest.relational.request.KomodoDataSourceJdbcTableAttributes;
+import org.komodo.rest.relational.request.KomodoDataserviceSingleSourceAttributes;
 import org.komodo.rest.relational.request.KomodoDataserviceUpdateAttributes;
 import org.komodo.rest.relational.request.KomodoFileAttributes;
 import org.komodo.rest.relational.request.KomodoPathAttribute;
@@ -82,6 +84,7 @@ import org.komodo.rest.schema.json.TeiidXsdReader;
 import org.komodo.spi.repository.KomodoType;
 import org.komodo.utils.ArgCheck;
 import org.komodo.utils.KLog;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -110,6 +113,7 @@ public final class KomodoJsonMarshaller {
                                                   .registerTypeAdapter(KomodoSearcherAttributes.class, new SearcherAttributesSerializer())
                                                   .registerTypeAdapter(KomodoTeiidAttributes.class, new TeiidAttributesSerializer())
                                                   .registerTypeAdapter(KomodoDataserviceUpdateAttributes.class, new DataserviceUpdateAttributesSerializer())
+                                                  .registerTypeAdapter(KomodoDataserviceSingleSourceAttributes.class, new DataserviceSingleSourceAttributesSerializer())
                                                   .registerTypeAdapter(KomodoDataSourceJdbcTableAttributes.class, new DataSourceJdbcTableAttributesSerializer())
                                                   .registerTypeAdapter(KomodoVdbUpdateAttributes.class, new VdbUpdateAttributesSerializer())
                                                   .registerTypeAdapter(RestProperty.class, new RestPropertySerializer())

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/request/KomodoDataserviceSingleSourceAttributes.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/request/KomodoDataserviceSingleSourceAttributes.java
@@ -1,0 +1,256 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational.request;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.core.MediaType;
+
+import org.komodo.rest.KRestEntity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+
+/**
+ * Object to be serialised by GSON that encapsulates properties for Dataservice single source request
+ */
+@JsonSerialize
+@JsonInclude(value=Include.NON_NULL)
+public class KomodoDataserviceSingleSourceAttributes implements KRestEntity {
+
+    /**
+     * Label for the DataService name
+     */
+    public static final String DATASERVICE_NAME_LABEL = "dataserviceName"; //$NON-NLS-1$
+
+    /**
+     * Label for the tablePath used for the update
+     */
+    public static final String DATASERVICE_TABLE_PATHS_LABEL = "tablePaths"; //$NON-NLS-1$
+
+    /**
+     * Label for the modelSourcePath used for the update
+     */
+    public static final String DATASERVICE_MODEL_SOURCE_PATH_LABEL = "modelSourcePath"; //$NON-NLS-1$
+
+    /**
+     * Label for the column names to include in the service view
+     */
+    public static final String DATASERVICE_COLUMN_NAMES_LABEL = "columnNames"; //$NON-NLS-1$
+
+    /**
+     * Label for the service view ddl
+     */
+    public static final String DATASERVICE_VIEW_DDL_LABEL = "viewDdl"; //$NON-NLS-1$
+
+    @JsonProperty(DATASERVICE_NAME_LABEL)
+    private String dataserviceName;
+
+    @JsonProperty(DATASERVICE_TABLE_PATHS_LABEL)
+    private List<String> tablePaths;
+
+    @JsonProperty(DATASERVICE_COLUMN_NAMES_LABEL)
+    private Map<String, List<String>> columnNames;
+
+    @JsonProperty(DATASERVICE_MODEL_SOURCE_PATH_LABEL)
+    private String modelSourcePath;
+
+    @JsonProperty(DATASERVICE_VIEW_DDL_LABEL)
+    private String viewDdl;
+
+    /**
+     * Default constructor for deserialization
+     */
+    public KomodoDataserviceSingleSourceAttributes() {
+        // do nothing
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean supports(MediaType mediaType) {
+        return MediaType.APPLICATION_JSON_TYPE.equals(mediaType);
+    }
+
+    @Override
+    @JsonIgnore
+    public Object getXml() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @return dataserviceName
+     */
+    public String getDataserviceName() {
+        return dataserviceName;
+    }
+
+    /**
+     * @param dataserviceName the dataservice name
+     */
+    public void setDataserviceName(String dataserviceName) {
+        this.dataserviceName = dataserviceName;
+    }
+
+    /**
+     * @return the table paths
+     */
+    public List<String> getTablePaths() {
+        if (tablePaths == null)
+            return Collections.emptyList();
+
+        return Collections.unmodifiableList(this.tablePaths);
+    }
+
+    /**
+     * set table paths
+     * @param tablePaths the table paths
+     */
+    public void setTablePaths(List<String> tablePaths) {
+        if (this.tablePaths == null)
+            this.tablePaths = new ArrayList<>();
+
+        this.tablePaths.addAll(tablePaths);
+    }
+
+    /**
+     * @return model source path
+     */
+    public String getModelSourcePath() {
+        return modelSourcePath;
+    }
+
+    /**
+     * @param modelSourcePath the source model path
+     */
+    public void setModelSourcePath(String modelSourcePath) {
+        this.modelSourcePath = modelSourcePath;
+    }
+    
+    /**
+     * @return the column names for each table
+     */
+    public Map<String,List<String>> getColumnNames() {
+        if (columnNames == null)
+            return Collections.emptyMap();
+
+        return Collections.unmodifiableMap(this.columnNames);
+    }
+
+    /**
+     * set the column names for each table
+     * @param columnNames the column names
+     */
+    public void setColumnNames(Map<String,List<String>> columnNames) {
+        if (this.columnNames == null)
+            this.columnNames = new HashMap<>();
+
+        this.columnNames.putAll(columnNames);
+    }
+    
+    /**
+     * @return view ddl
+     */
+    public String getViewDdl() {
+        return viewDdl;
+    }
+
+    /**
+     * @param ddl the view ddl
+     */
+    public void setViewDdl(String ddl) {
+        this.viewDdl = ddl;
+    }
+
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((dataserviceName == null) ? 0 : dataserviceName.hashCode());
+        result = prime * result + ((tablePaths == null) ? 0 : tablePaths.hashCode());
+        result = prime * result + ((modelSourcePath == null) ? 0 : modelSourcePath.hashCode());
+        result = prime * result + ((columnNames == null) ? 0 : columnNames.hashCode());
+        result = prime * result + ((viewDdl == null) ? 0 : viewDdl.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        KomodoDataserviceSingleSourceAttributes other = (KomodoDataserviceSingleSourceAttributes)obj;
+        if (dataserviceName == null) {
+            if (other.dataserviceName != null)
+                return false;
+        } else if (!dataserviceName.equals(other.dataserviceName))
+            return false;
+        if (tablePaths == null) {
+            if (other.tablePaths != null)
+                return false;
+        } else if (!tablePaths.equals(other.tablePaths))
+            return false;
+        if (modelSourcePath == null) {
+            if (other.modelSourcePath != null)
+                return false;
+        } else if (!modelSourcePath.equals(other.modelSourcePath))
+            return false;
+        if (columnNames == null) {
+            if (other.columnNames != null)
+                return false;
+        } else if (!columnNames.equals(other.columnNames))
+            return false;
+        if (viewDdl == null) {
+            if (other.viewDdl != null)
+                return false;
+        } else if (!viewDdl.equals(other.viewDdl))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("KomodoDataserviceUpdateAttributes [dataserviceName=" + dataserviceName + ", modelSourcePath=" + modelSourcePath);
+        if(tablePaths!=null) {
+            sb.append(", tablePaths length =" + tablePaths.size());
+        }
+        if(columnNames!=null) {
+            sb.append(", columnNames length =" + columnNames.size());
+        }
+        if(viewDdl!=null) {
+            sb.append(", viewDdl =" + viewDdl);
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoMetadataService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoMetadataService.java
@@ -2467,7 +2467,15 @@ public class KomodoMetadataService extends KomodoService {
     }
     
     private boolean isJdbc(TeiidDataSource dataSource) {
-        return dataSource.getPropertyValue("bob") != null;
+    	// TODO: re-evaluate for better approach.  (We will probably not need this method after schema retrieval changes)
+    	String dsDriverName = dataSource.getPropertyValue(TeiidDataSource.DATASOURCE_DRIVERNAME);
+        
+        if (dsDriverName == null || dsDriverName.equals("cassandra") || dsDriverName.equals("file") || dsDriverName.equals("google")
+                            || dsDriverName.equals("ldap") || dsDriverName.equals("mongodb") || dsDriverName.equals("salesforce")
+                            || dsDriverName.equals("salesforce-34") || dsDriverName.equals("solr") || dsDriverName.equals("webservice")) {
+          return false;
+        }
+        return true;
     }
 
     /**

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/RestDataserviceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/RestDataserviceTest.java
@@ -54,7 +54,8 @@ public final class RestDataserviceTest {
     private static final String SERVICE_VDB_NAME = "serviceVdbName";
     private static final String SERVICE_VDB_VERSION = "1";
     private static final String SERVICE_VIEW_MODEL = "serviceViewModel";
-    private static final String SERVICE_VIEW = "serviceView";
+    private static final String SERVICE_VIEW1 = "serviceView1";
+    private static final String SERVICE_VIEW2 = "serviceView2";
     private static final String SERVICE_VIEW_SRCTABLE1 = "sourceTable1";
     private static final String SERVICE_VIEW_SRCTABLE2 = "sourceTable2";
 
@@ -74,7 +75,7 @@ public final class RestDataserviceTest {
         copy.setServiceVdbName(this.dataservice.getServiceVdbName());
         copy.setServiceVdbVersion(this.dataservice.getServiceVdbVersion());
         copy.setServiceViewModel(this.dataservice.getServiceViewModel());
-        copy.setServiceViewName(this.dataservice.getServiceViewName());
+        copy.setServiceViewNames(this.dataservice.getServiceViewNames());
         copy.setServiceViewTables(this.dataservice.getServiceViewTables());
         copy.setDriverTotal(this.dataservice.getDriverTotal());
         copy.setConnectionTotal(this.dataservice.getConnectionTotal());
@@ -115,7 +116,10 @@ public final class RestDataserviceTest {
         this.dataservice.setServiceVdbName(SERVICE_VDB_NAME);
         this.dataservice.setServiceVdbVersion(SERVICE_VDB_VERSION);
         this.dataservice.setServiceViewModel(SERVICE_VIEW_MODEL);
-        this.dataservice.setServiceViewName(SERVICE_VIEW);
+        String[] viewNames = new String[2];
+        viewNames[0] = SERVICE_VIEW1;
+        viewNames[1] = SERVICE_VIEW2;
+        this.dataservice.setServiceViewNames(viewNames);
         String[] viewTables = new String[2];
         viewTables[0] = SERVICE_VIEW_SRCTABLE1;
         viewTables[1] = SERVICE_VIEW_SRCTABLE2;
@@ -200,9 +204,11 @@ public final class RestDataserviceTest {
 
     @Test
     public void shouldSetServiceView() {
-        final String newServiceView = "blah";
-        this.dataservice.setServiceViewName(newServiceView);
-        assertEquals(this.dataservice.getServiceViewName(), newServiceView);
+    	final String[] views = new String[2];
+    	views[0] = "blah1";
+    	views[1] = "blah2";
+        this.dataservice.setServiceViewNames(views);
+        assertEquals(this.dataservice.getServiceViewNames(), views);
     }
 
 

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/unit/KomodoDataserviceServiceTestInSuite.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/unit/KomodoDataserviceServiceTestInSuite.java
@@ -29,13 +29,17 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
+
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpGet;
@@ -52,6 +56,7 @@ import org.komodo.rest.relational.KomodoRestUriBuilder.SettingNames;
 import org.komodo.rest.relational.connection.RestConnection;
 import org.komodo.rest.relational.dataservice.RestDataservice;
 import org.komodo.rest.relational.json.KomodoJsonMarshaller;
+import org.komodo.rest.relational.request.KomodoDataserviceSingleSourceAttributes;
 import org.komodo.rest.relational.request.KomodoDataserviceUpdateAttributes;
 import org.komodo.rest.relational.response.RestConnectionDriver;
 import org.komodo.rest.relational.response.RestDataserviceViewInfo;
@@ -398,21 +403,26 @@ public class KomodoDataserviceServiceTestInSuite extends AbstractKomodoServiceTe
     }
 
     @Test
-    public void shouldNotSetServiceVdbForSingleTableMissingParameter() throws Exception {
-        String dataserviceName = "shouldNotSetServiceVdbForSingleTableMissingParameter";
+    public void shouldNotSetServiceVdbForSingleSourceTablesMissingParameter() throws Exception {
+        String dataserviceName = "shouldNotSetServiceVdbForSingleSourceTablesMissingParameter";
         createDataservice(dataserviceName);
         URI dataservicesUri = uriBuilder().workspaceDataservicesUri();
-        URI uri = UriBuilder.fromUri(dataservicesUri).path(V1Constants.SERVICE_VDB_FOR_SINGLE_TABLE).build();
+        URI uri = UriBuilder.fromUri(dataservicesUri).path(V1Constants.SERVICE_VDB_FOR_SINGLE_SOURCE_TABLES).build();
 
         // Required parms (dataserviceName, modelSourcePath, tablePath).
         // fails due to missing modelSourcePath
-        KomodoDataserviceUpdateAttributes updateAttr = new KomodoDataserviceUpdateAttributes();
-        updateAttr.setDataserviceName(dataserviceName);
-        updateAttr.setTablePath("/path/to/table");
+        KomodoDataserviceSingleSourceAttributes ssrcAttr = new KomodoDataserviceSingleSourceAttributes();
+        ssrcAttr.setDataserviceName(dataserviceName);
+        // List of Table paths
+        List<String> tablePaths = new ArrayList<String>();
+        String tablePath = "tko:komodo/tko:workspace/" + USER_NAME + "/Portfolio/PersonalValuations/Sheet1";
+        tablePaths.add(tablePath);
+        tablePaths.add(tablePath);
+        ssrcAttr.setTablePaths(tablePaths);
 
         HttpPost request = jsonRequest(uri, RequestType.POST);
         addJsonConsumeContentType(request);
-        addBody(request, updateAttr);
+        addBody(request, ssrcAttr);
 
         HttpResponse response = execute(request);
 
@@ -423,22 +433,27 @@ public class KomodoDataserviceServiceTestInSuite extends AbstractKomodoServiceTe
     }
 
     @Test
-    public void shouldNotSetServiceVdbForSingleTableBadTablePath() throws Exception {
-        String dataserviceName = "shouldNotSetServiceVdbForSingleTableBadTablePath";
+    public void shouldNotSetServiceVdbForSingleSourceTablesBadTablePath() throws Exception {
+        String dataserviceName = "shouldNotSetServiceVdbForSingleSourceTablesBadTablePath";
         createDataservice(dataserviceName);
         URI dataservicesUri = uriBuilder().workspaceDataservicesUri();
-        URI uri = UriBuilder.fromUri(dataservicesUri).path(V1Constants.SERVICE_VDB_FOR_SINGLE_TABLE).build();
+        URI uri = UriBuilder.fromUri(dataservicesUri).path(V1Constants.SERVICE_VDB_FOR_SINGLE_SOURCE_TABLES).build();
 
         // Required parms (dataserviceName, modelSourcePath, tablePath).
         // fails due to bad table path - (doesnt resolve to a table)
-        KomodoDataserviceUpdateAttributes updateAttr = new KomodoDataserviceUpdateAttributes();
-        updateAttr.setDataserviceName(dataserviceName);
-        updateAttr.setTablePath("/path/to/table");
-        updateAttr.setModelSourcePath("/path/to/ModelSource");
+        KomodoDataserviceSingleSourceAttributes ssrcAttr = new KomodoDataserviceSingleSourceAttributes();
+        ssrcAttr.setDataserviceName(dataserviceName);
+        // List of Table paths
+        List<String> tablePaths = new ArrayList<String>();
+        String tablePath = "/path/to/table";
+        tablePaths.add(tablePath);
+        tablePaths.add(tablePath);
+        ssrcAttr.setTablePaths(tablePaths);
+        ssrcAttr.setModelSourcePath("/path/to/ModelSource");
 
         HttpPost request = jsonRequest(uri, RequestType.POST);
         addJsonConsumeContentType(request);
-        addBody(request, updateAttr);
+        addBody(request, ssrcAttr);
 
         HttpResponse response = execute(request);
 
@@ -449,21 +464,27 @@ public class KomodoDataserviceServiceTestInSuite extends AbstractKomodoServiceTe
     }
 
     @Test
-    public void shouldNotSetServiceVdbForSingleTableBadDdl() throws Exception {
-        String dataserviceName = "shouldNotSetServiceVdbForSingleTableBadDdl";
+    public void shouldNotSetServiceVdbForSingleSourceTablesBadDdl() throws Exception {
+        String dataserviceName = "shouldNotSetServiceVdbForSingleSourceTablesBadDdl";
         createDataservice(dataserviceName);
         URI dataservicesUri = uriBuilder().workspaceDataservicesUri();
-        URI uri = UriBuilder.fromUri(dataservicesUri).path(V1Constants.SERVICE_VDB_FOR_SINGLE_TABLE).build();
+        URI uri = UriBuilder.fromUri(dataservicesUri).path(V1Constants.SERVICE_VDB_FOR_SINGLE_SOURCE_TABLES).build();
 
-        KomodoDataserviceUpdateAttributes updateAttr = new KomodoDataserviceUpdateAttributes();
-        updateAttr.setDataserviceName(dataserviceName);
-        updateAttr.setTablePath("tko:komodo/tko:workspace/" + USER_NAME + "/Portfolio/PersonalValuations/Sheet1");
-        updateAttr.setModelSourcePath("tko:komodo/tko:workspace/" + USER_NAME + "/Portfolio/Accounts/vdb:sources/h2-connector");
-        updateAttr.setViewDdl("CREATE VIEW blah blah");
+        KomodoDataserviceSingleSourceAttributes ssrcAttr = new KomodoDataserviceSingleSourceAttributes();
+        ssrcAttr.setDataserviceName(dataserviceName);
+        // List of Table paths
+        List<String> tablePaths = new ArrayList<String>();
+        String tablePath = "tko:komodo/tko:workspace/" + USER_NAME + "/Portfolio/PersonalValuations/Sheet1";
+        tablePaths.add(tablePath);
+        tablePaths.add(tablePath);
+        ssrcAttr.setTablePaths(tablePaths);
+
+        ssrcAttr.setModelSourcePath("tko:komodo/tko:workspace/" + USER_NAME + "/Portfolio/Accounts/vdb:sources/h2-connector");
+        ssrcAttr.setViewDdl("CREATE VIEW blah blah");
 
         HttpPost request = jsonRequest(uri, RequestType.POST);
         addJsonConsumeContentType(request);
-        addBody(request, updateAttr);
+        addBody(request, ssrcAttr);
 
         try {
             HttpResponse response = execute(request);
@@ -482,20 +503,25 @@ public class KomodoDataserviceServiceTestInSuite extends AbstractKomodoServiceTe
     }
 
     @Test
-    public void shouldSetServiceVdbForSingleTable() throws Exception {
-        String dataserviceName = "shouldSetServiceVdbForSingleTable";
+    public void shouldSetServiceVdbForSingleSourceTables() throws Exception {
+        String dataserviceName = "shouldSetServiceVdbForSingleSourceTables";
         createDataservice(dataserviceName);
         URI dataservicesUri = uriBuilder().workspaceDataservicesUri();
-        URI uri = UriBuilder.fromUri(dataservicesUri).path(V1Constants.SERVICE_VDB_FOR_SINGLE_TABLE).build();
+        URI uri = UriBuilder.fromUri(dataservicesUri).path(V1Constants.SERVICE_VDB_FOR_SINGLE_SOURCE_TABLES).build();
 
-        KomodoDataserviceUpdateAttributes updateAttr = new KomodoDataserviceUpdateAttributes();
-        updateAttr.setDataserviceName(dataserviceName);
-        updateAttr.setTablePath("tko:komodo/tko:workspace/" + USER_NAME + "/Portfolio/PersonalValuations/Sheet1");
-        updateAttr.setModelSourcePath("tko:komodo/tko:workspace/" + USER_NAME + "/Portfolio/Accounts/vdb:sources/h2-connector");
+        KomodoDataserviceSingleSourceAttributes ssrcAttr = new KomodoDataserviceSingleSourceAttributes();
+        ssrcAttr.setDataserviceName(dataserviceName);
+        // List of Table paths
+        List<String> tablePaths = new ArrayList<String>();
+        String tablePath = "tko:komodo/tko:workspace/" + USER_NAME + "/Portfolio/PersonalValuations/Sheet1";
+        tablePaths.add(tablePath);
+        tablePaths.add(tablePath);
+        ssrcAttr.setTablePaths(tablePaths);
+        ssrcAttr.setModelSourcePath("tko:komodo/tko:workspace/" + USER_NAME + "/Portfolio/Accounts/vdb:sources/h2-connector");
 
         HttpPost request = jsonRequest(uri, RequestType.POST);
         addJsonConsumeContentType(request);
-        addBody(request, updateAttr);
+        addBody(request, ssrcAttr);
 
         try {
             HttpResponse response = execute(request);
@@ -512,7 +538,7 @@ public class KomodoDataserviceServiceTestInSuite extends AbstractKomodoServiceTe
                 logObjectPath(vdb.getAbsolutePath());
         }
     }
-
+    
     @Test
     public void shouldNotSetServiceVdbForJoinTablesMissingParameter() throws Exception {
         String dataserviceName = "shouldNotSetServiceVdbForJoinTablesMissingParameter";


### PR DESCRIPTION
TEIIDTOOLS-323
(This PR has a companion beetle-studio PR)
- modifies DataserviceService rest method to accept multiple tables, which are then used to generate the service views
- modifies Dataservice getServiceView(s) to return array of view names rather than single view
- fixed associated tests
