### PR TITLE
TEIIDTOOLS-357

### DIFF
--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
@@ -284,6 +284,11 @@ public class KomodoRestV1Application extends Application implements SystemConsta
         String CONNECTION_PLACEHOLDER = "{connectionName}"; //$NON-NLS-1$
 
         /**
+         * The name of the URI path segment for deploying connection VDB
+         */
+        String CONNECTION_DEPLOY_VDB_SEGMENT = "deployVdb"; //$NON-NLS-1$
+        
+        /**
          * The name of the URI path segment for service catalog.
          */
         String SERVICE_CATALOG_SEGMENT = "serviceCatalog"; //$NON-NLS-1$
@@ -547,6 +552,11 @@ public class KomodoRestV1Application extends Application implements SystemConsta
          * The teiid status path segment
          */
         String STATUS_SEGMENT = "status"; //$NON-NLS-1$
+
+        /**
+         * The teiid VDB status path segment
+         */
+        String VDB_STATUS_SEGMENT = "vdbStatus"; //$NON-NLS-1$
 
         /**
          * The name of the resource used for importing and exporting artifacts

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -434,6 +434,11 @@ public final class RelationalMessages {
         DATASERVICE_SERVICE_NAME_VALIDATION_ERROR,
 
         /**
+         * An error indicating attempt to get dataservice VDB statuses failed
+         */
+        DATASERVICE_SERVICE_VDBS_STATUS_ERROR,
+
+        /**
          * An error indicating a JSON document representing the Connections in the workspace could not be retrieved.
          */
         CONNECTION_SERVICE_GET_CONNECTIONS_ERROR,
@@ -464,14 +469,9 @@ public final class RelationalMessages {
         CONNECTION_SERVICE_UPDATE_CONNECTION_ERROR,
 
         /**
-         * An error indicating create attempt was missing a name
+         * An error indicating the operation was missing the connection name
          */
-        CONNECTION_SERVICE_CREATE_MISSING_NAME,
- 
-        /**
-         * An error indicating clone attempt was missing a name
-         */
-        CONNECTION_SERVICE_CLONE_MISSING_NAME,
+        CONNECTION_SERVICE_MISSING_NAME,
  
         /**
          * An error indicating clone attempt was missing a new connection name
@@ -482,11 +482,6 @@ public final class RelationalMessages {
          * An error indicating the desired new clone name is same as connection being cloned
          */
         CONNECTION_SERVICE_CLONE_SAME_NAME_ERROR,
-        
-        /**
-         * An error indicating update attempt was missing a name
-         */
-        CONNECTION_SERVICE_UPDATE_MISSING_NAME,
         
         /**
          * An error indicating that the connection does not exist
@@ -529,6 +524,11 @@ public final class RelationalMessages {
         CONNECTION_SERVICE_NAME_VALIDATION_ERROR,
 
         /**
+         * A message indicating an unexpected error occurred during connection VDB deployment
+         */
+        CONNECTION_SERVICE_DEPLOY_CONNECTION_VDB_ERROR,
+        
+        /**
          * An error indicating at least one parameter is lacking
          */
         CONNECTION_SERVICE_MISSING_PARAMETER_ERROR,
@@ -543,6 +543,11 @@ public final class RelationalMessages {
          */
         CONNECTION_SERVICE_CATALOG_SOURCE_DNE_ERROR,
         
+        /**
+         * An error indicating attempt to get connection VDB statuses failed
+         */
+        CONNECTION_SERVICE_VDBS_STATUS_ERROR,
+
         /**
          * Error transferring connections from server to repo
          */

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/MetadataVdbStatusVdbSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/MetadataVdbStatusVdbSerializer.java
@@ -93,30 +93,32 @@ public final class MetadataVdbStatusVdbSerializer extends TypeAdapter< RestMetad
 
         out.beginObject();
 
-        out.name(RestMetadataVdbStatusVdb.VDB_STATUS_NAME);
-        out.value(value.getName());
+        if(value.getType() == RestMetadataVdbStatusVdb.Type.VDB) {
+        	out.name(RestMetadataVdbStatusVdb.VDB_STATUS_NAME);
+        	out.value(value.getName());
 
-        out.name(RestMetadataVdbStatusVdb.VDB_STATUS_DEPLOYED_NAME);
-        out.value(value.getDeployedName());
+        	out.name(RestMetadataVdbStatusVdb.VDB_STATUS_DEPLOYED_NAME);
+        	out.value(value.getDeployedName());
 
-        out.name(RestMetadataVdbStatusVdb.VDB_STATUS_VERSION);
-        out.value(value.getVersion());
+        	out.name(RestMetadataVdbStatusVdb.VDB_STATUS_VERSION);
+        	out.value(value.getVersion());
 
-        out.name(RestMetadataVdbStatusVdb.VDB_STATUS_ACTIVE);
-        out.value(value.isActive());
+        	out.name(RestMetadataVdbStatusVdb.VDB_STATUS_ACTIVE);
+        	out.value(value.isActive());
 
-        out.name(RestMetadataVdbStatusVdb.VDB_STATUS_LOADING);
-        out.value(value.isLoading());
+        	out.name(RestMetadataVdbStatusVdb.VDB_STATUS_LOADING);
+        	out.value(value.isLoading());
 
-        out.name(RestMetadataVdbStatusVdb.VDB_STATUS_FAILED);
-        out.value(value.isFailed());
+        	out.name(RestMetadataVdbStatusVdb.VDB_STATUS_FAILED);
+        	out.value(value.isFailed());
 
-        out.name(RestMetadataVdbStatusVdb.VDB_STATUS_ERROR);
-        out.beginArray();
-        for (String val: value.getErrors()) {
-            out.value(val);
+        	out.name(RestMetadataVdbStatusVdb.VDB_STATUS_ERROR);
+        	out.beginArray();
+        	for (String val: value.getErrors()) {
+        		out.value(val);
+        	}
+        	out.endArray();
         }
-        out.endArray();
 
         out.endObject();
     }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/RestObjectVdbStatus.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/RestObjectVdbStatus.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational.response;
+
+import javax.ws.rs.core.MediaType;
+
+import org.komodo.rest.KRestEntity;
+import org.komodo.rest.relational.response.metadata.RestMetadataVdbStatusVdb;
+
+/**
+ * Rest entity which holds RestMetadataVdbStatusVdb associated with an object
+ */
+public class RestObjectVdbStatus implements KRestEntity {
+
+    public static final String OBJECT_NAME_LABEL = "objectName";
+
+    public static final String VDB_STATUS_LABEL = "vdbStatus";
+
+    private String name;
+
+    private RestMetadataVdbStatusVdb vdbStatus;
+
+    /**
+     * Constructor for use when deserializing
+     */
+    public RestObjectVdbStatus() {
+        super();
+    }
+
+    public RestObjectVdbStatus(String name, RestMetadataVdbStatusVdb status) {
+        this.name = name;
+        this.vdbStatus = status;
+    }
+
+    @Override
+    public Object getXml() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean supports(MediaType mediaType) {
+        return MediaType.APPLICATION_JSON_TYPE.equals(mediaType)
+        || MediaType.APPLICATION_XML_TYPE.equals(mediaType);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public RestMetadataVdbStatusVdb getVdbStatus() {
+        return vdbStatus;
+    }
+
+    public void setVdbStatus(RestMetadataVdbStatusVdb status) {
+    	this.vdbStatus = status;
+    }
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/metadata/RestMetadataVdbStatusVdb.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/metadata/RestMetadataVdbStatusVdb.java
@@ -39,6 +39,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @JsonInclude(value=Include.NON_NULL)
 public class RestMetadataVdbStatusVdb implements KRestEntity {
 
+    public enum Type {EMPTY_VDB, VDB}
+
     /**
      * Label for the name
      */
@@ -74,6 +76,8 @@ public class RestMetadataVdbStatusVdb implements KRestEntity {
      */
     public static final String VDB_STATUS_ERROR = "errors";
 
+    private Type type = Type.VDB;
+
     private String name;
 
     private String deployedName;
@@ -88,6 +92,20 @@ public class RestMetadataVdbStatusVdb implements KRestEntity {
 
     private List<String> errors;
 
+    // Private static instance for not found VDBs
+    private static RestMetadataVdbStatusVdb emptyVDBInstance = new RestMetadataVdbStatusVdb(Type.EMPTY_VDB);
+     
+ 
+    // Private Constructor for empty VDB
+    private RestMetadataVdbStatusVdb(Type vdbType){
+         type = vdbType;
+    }
+     
+    // Static method to return the empty VDB
+    public static RestMetadataVdbStatusVdb emptyVdb(){
+        return emptyVDBInstance;
+    }
+    
     /**
      * Default constructor for deserialization
      */
@@ -113,6 +131,14 @@ public class RestMetadataVdbStatusVdb implements KRestEntity {
     @Override
     public Object getXml() {
         throw new UnsupportedOperationException();
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public void setType(Type type) {
+        this.type = type;
     }
 
     public String getName() {
@@ -175,6 +201,7 @@ public class RestMetadataVdbStatusVdb implements KRestEntity {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
         result = prime * result + (active ? 1231 : 1237);
         result = prime * result + ((deployedName == null) ? 0 : deployedName.hashCode());
         result = prime * result + ((errors == null) ? 0 : errors.hashCode());
@@ -194,6 +221,8 @@ public class RestMetadataVdbStatusVdb implements KRestEntity {
         if (getClass() != obj.getClass())
             return false;
         RestMetadataVdbStatusVdb other = (RestMetadataVdbStatusVdb)obj;
+        if (type != other.type)
+            return false;
         if (active != other.active)
             return false;
         if (deployedName == null) {

--- a/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -175,6 +175,7 @@ Error.DATASERVICE_SERVICE_SET_SERVICE_MISSING_JOIN_RH_COLUMN = The join right cr
 Error.DATASERVICE_SERVICE_SET_SERVICE_MISSING_VIEWDDL = The service view DDL is required for this operation for DataService: %s
 Error.DATASERVICE_SERVICE_NAME_EXISTS = A data service, data source, or other workspace object with the same name and path already exists.
 Error.DATASERVICE_SERVICE_NAME_VALIDATION_ERROR = An error occurred trying to validate the data service name.
+Error.DATASERVICE_SERVICE_VDBS_STATUS_ERROR = An error occurred trying to get Dataservice VDB statuses.
 
 Error.DATASOURCE_SERVICE_GET_CONNECTIONS_ERROR = An error occurred constructing the JSON document representing the Connections in the Komodo workspace: %s
 Error.CONNECTION_SERVICE_GET_CONNECTION_ERROR = An error occurred constructing the JSON document for Connection: %s
@@ -183,9 +184,7 @@ Error.CONNECTION_SERVICE_CREATE_CONNECTION_ERROR = An error occurred while creat
 Error.CONNECTION_SERVICE_DELETE_CONNECTION_ERROR = An error occurred while deleting a connection from the repository: %s
 Error.CONNECTION_SERVICE_CLONE_CONNECTION_ERROR = An error occurred while cloning a connection in the repository: %s
 Error.CONNECTION_SERVICE_UPDATE_CONNECTION_ERROR = An error occurred while updating a connection from the repository: %s
-Error.CONNECTION_SERVICE_CREATE_MISSING_NAME = The name is required when creating a Connection.
-Error.CONNECTION_SERVICE_UPDATE_MISSING_NAME = The name is required when updating a Connection.
-Error.CONNECTION_SERVICE_CLONE_MISSING_NAME = The name is required when cloning a Connection.
+Error.CONNECTION_SERVICE_MISSING_NAME = The connection name is required for this operation.
 Error.CONNECTION_SERVICE_CLONE_MISSING_NEW_NAME = The new name is required when cloning a Connection.
 Error.CONNECTION_SERVICE_CLONE_SAME_NAME_ERROR = The new name '%s' cannot be the same as the Connection being cloned.
 Error.CONNECTION_SERVICE_UPDATE_CONNECTION_DNE = The Connection requested to update does not exist.
@@ -199,6 +198,8 @@ Error.CONNECTION_SERVICE_JSON_MISSING_NAME = A name is missing from the input Co
 Error.CONNECTION_SERVICE_SERVICE_NAME_ERROR = The name parameter %s and JSON %s do not match so a Connection cannot be created.
 Error.CONNECTION_SERVICE_NAME_EXISTS = A Connection must have a different name than an existing connection or data source.
 Error.CONNECTION_SERVICE_NAME_VALIDATION_ERROR = An error occurred trying to validate the VDB name.
+Error.CONNECTION_SERVICE_DEPLOY_CONNECTION_VDB_ERROR = An error occurred trying to deploy a VDB for the connection.
+Error.CONNECTION_SERVICE_VDBS_STATUS_ERROR = An error occurred trying to get Connection VDB statuses.
 Error.CONNECTION_TO_REPO_IMPORT_ERROR = One or more Connections failed to import into the workspace: %s
 
 Error.SCHEMA_SERVICE_GET_SCHEMA_ERROR = An error occurred constructing the JSON document representing the metadata schema: %s


### PR DESCRIPTION
Changes to the rest interfaces to support management of connection VDBs
- Add KomodoConnectionService method which deploys a VDB for a given connection.
- Adds KomodoConnectionService method which returns VDBStatus for all workspace Connection objects.
- Adds KomodoDataserviceService method which returns VDBStatus for all workspace Dataservice objects.
- modified RestMetadataVdbStatusVdb and serializer to support instance when no VDB exists for the workspace object; in that case returns empty status.
- remove unused method in KomodoDataserviceService and other minor removals.