### PR TITLE
Moves and renames model source's associated connection

### DIFF
--- a/komodo-core/src/main/java/org/komodo/core/KomodoLexicon.java
+++ b/komodo-core/src/main/java/org/komodo/core/KomodoLexicon.java
@@ -824,11 +824,6 @@ public interface KomodoLexicon extends StringConstants {
          * The name of the translator property. Value is {@value} .
          */
         String TRANSLATOR = "vdb:sourceTranslator"; //$NON-NLS-1$
-
-        /**
-         * The name of the associated connection property. Value is {@value} .
-         */
-        String ASSOCIATED_CONNECTION = Namespace.PREFIX + COLON + "associatedConnection"; //$NON-NLS-1$
     }
 
     /**

--- a/komodo-parent/pom.xml
+++ b/komodo-parent/pom.xml
@@ -158,7 +158,7 @@
 		<version.org.jboss.xnio>3.5.1.Final</version.org.jboss.xnio>
 		
 		<version.modeshape>5.4.1.Final</version.modeshape>
-		<version.teiid.modeshape>1.0.0.Final</version.teiid.modeshape>
+		<version.teiid.modeshape>1.0.1.Final</version.teiid.modeshape>
 		<version.postgresql>42.1.4</version.postgresql>
 		<version.xerces>2.9.1</version.xerces>		
 		<version.wildfly.swarm>2018.2.0</version.wildfly.swarm>

--- a/komodo-relational/src/main/java/org/komodo/relational/vdb/ModelSource.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/vdb/ModelSource.java
@@ -142,7 +142,7 @@ public interface ModelSource extends RelationalObject {
      * @throws KException
      *         if an error occurs
      */
-    Connection getAssociatedConnection( final UnitOfWork transaction ) throws KException;
+    Connection getOriginConnection( final UnitOfWork transaction ) throws KException;
 
     /**
      * @param transaction

--- a/komodo-spi/src/main/java/org/komodo/spi/lexicon/vdb/VdbLexicon.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/lexicon/vdb/VdbLexicon.java
@@ -87,6 +87,11 @@ public interface VdbLexicon {
         String JNDI_NAME = Namespace.PREFIX + ":sourceJndiName";
         String SOURCE = Namespace.PREFIX + ":source";
         String TRANSLATOR = Namespace.PREFIX + ":sourceTranslator";
+
+        /**
+         * The name of the origin connection property. Value is {@value} .
+         */
+        String ORIGIN_CONNECTION = Namespace.PREFIX + ":originConnection";
     }
 
     /**
@@ -140,6 +145,7 @@ public interface VdbLexicon {
         String MODEL = "model";
         String NAME = "name";
         String ORDER = "order";
+        String ORIGIN_SRC_CONNECTION = "origin-conn-src";
         String PATH = "path";
         String PERMISSION = "permission";
         String PREVIEW = "preview";

--- a/komodo-utils/src/test/resources/org/komodo/test/utils/USStates-source-vdb.xml
+++ b/komodo-utils/src/test/resources/org/komodo/test/utils/USStates-source-vdb.xml
@@ -9,6 +9,7 @@
 <property name="importer.UseQualifiedName" value="false"/>
 <property name="importer.UseCatalogName" value="false"/>
 <property name="importer.TableTypes" value="TABLE"/>
+<property name="origin-conn-src-USStates" value="USStatesConnection"></property>
 <source name="USStates" translator-name="h2" connection-jndi-name="java:/USStatesSource"/>
 </model>
 

--- a/komodo-utils/src/test/resources/org/komodo/test/utils/books.xml
+++ b/komodo-utils/src/test/resources/org/komodo/test/utils/books.xml
@@ -32,6 +32,7 @@ CREATE VIEW bookInfo (
         ]]> </metadata>
     </model>
     <model name="BooksSource" type="PHYSICAL" visible="true">
+        <property name="origin-conn-src-BooksSource" value="BooksSrcConnection1"></property>
         <source name="BooksSource" connection-jndi-name="BooksSource" translator-name="db2"/>
     </model>
     <translator name="books_db2" type="db2" description="">

--- a/komodo-utils/src/test/resources/org/komodo/test/utils/notranslator-descrip-vdb.xml
+++ b/komodo-utils/src/test/resources/org/komodo/test/utils/notranslator-descrip-vdb.xml
@@ -7,6 +7,7 @@
  	<property name="UseConnectorMetadata" value="cached" />
 
     <model name="twitter" type="PHYSICAL">
+        <property name="origin-conn-src-twitter" value="twitterConnection1"></property>
         <source name="twitter" translator-name="rest" connection-jndi-name="java:/twitterDS"/>
     </model>
     <model name="twitterview" type="VIRTUAL">

--- a/komodo-utils/src/test/resources/org/komodo/test/utils/parts_dynamic-vdb.xml
+++ b/komodo-utils/src/test/resources/org/komodo/test/utils/parts_dynamic-vdb.xml
@@ -20,6 +20,7 @@ SELECT PartsSS.PARTS.PART_ID, PartsSS.PARTS.PART_NAME, PartsSS.PARTS.PART_COLOR,
 		</metadata>
 	</model>
 	<model name="PartsSS" type="PHYSICAL">
+	    <property name="origin-conn-src-PartsSS" value="PartsSSConnection1"></property>
 		<source name="PartsSS" translator-name="sqlserver" connection-jndi-name="PartsSS"></source>
 		<metadata type="DDL">
 			<![CDATA[CREATE FOREIGN TABLE PARTS (

--- a/komodo-utils/src/test/resources/org/komodo/test/utils/parts_dynamic_withkeys-vdb.xml
+++ b/komodo-utils/src/test/resources/org/komodo/test/utils/parts_dynamic_withkeys-vdb.xml
@@ -20,6 +20,7 @@ SELECT PartsSS.PARTS.PART_ID, PartsSS.PARTS.PART_NAME, PartsSS.PARTS.PART_COLOR,
 		</metadata>
 	</model>
 	<model name="PartsSS" type="PHYSICAL">
+	    <property name="origin-conn-src-PartsSS" value="PartsSSConnection1"></property>
 		<source name="PartsSS" translator-name="sqlserver" connection-jndi-name="PartsSS"></source>
 		<metadata type="DDL">
 			<![CDATA[CREATE FOREIGN TABLE PARTS (

--- a/komodo-utils/src/test/resources/org/komodo/test/utils/patients-vdb.xml
+++ b/komodo-utils/src/test/resources/org/komodo/test/utils/patients-vdb.xml
@@ -24,6 +24,7 @@
         </metadata>
     </model>
     <model name="PatientSource" type="PHYSICAL">
+        <property name="origin-conn-src-PatientSource" value="PatientSourceConnection1"></property>
         <source name="PatientSource" translator-name="mysql5" connection-jndi-name="java:/MySqlPatients"/>
     </model>
 

--- a/komodo-utils/src/test/resources/org/komodo/test/utils/portfolio-vdb.xml
+++ b/komodo-utils/src/test/resources/org/komodo/test/utils/portfolio-vdb.xml
@@ -26,6 +26,7 @@
             Each source represents a translator and data source. There are
             pre-defined translators, or you can create one.
         -->
+        <property name="assoc-conn-text-connector" value="TextConnection1"></property>
         <source name="text-connector" translator-name="file" connection-jndi-name="java:/marketdata-file"/>
     </model>
  
@@ -45,6 +46,7 @@
  
           -->
  
+        <property name="origin-conn-src-h2-connector" value="H2Connection1"></property>
         <source name="h2-connector" translator-name="h2" connection-jndi-name="java:/accounts-ds"/>
  
     </model>
@@ -52,6 +54,7 @@
     <model name="PersonalValuations">
         <property name="importer.headerRowNumber" value="1"/>
         <property name="importer.ExcelFileName" value="otherholdings.xls"/>
+        <property name="origin-conn-src-excelconnector" value="ExcelConnection1"></property>
         <source name="excelconnector" translator-name="excel"  connection-jndi-name="java:/excel-file"/>
         <metadata type="DDL"><![CDATA[
  

--- a/komodo-utils/src/test/resources/org/komodo/test/utils/roles-vdb.xml
+++ b/komodo-utils/src/test/resources/org/komodo/test/utils/roles-vdb.xml
@@ -1,5 +1,6 @@
 <vdb name="z" version="1">
     <model name="myschema">
+        <property name="origin-conn-src-hc" value="HCConnection1"></property>
     	<source name="hc" translator-name="hc" connection-jndi-name="hc"/>
     </model>
     <data-role name="y" any-authenticated="true"/>

--- a/komodo-utils/src/test/resources/org/komodo/test/utils/sample-vdb.xml
+++ b/komodo-utils/src/test/resources/org/komodo/test/utils/sample-vdb.xml
@@ -7,6 +7,7 @@
     <property name="{http://teiid.org/rest}security-role" value="example-role"/>
     
     <model name="Txns">
+        <property name="origin-conn-src-text-connector" value="TextConnection1"></property>
         <source name="text-connector" translator-name="loopback" />
          <metadata type="DDL"><![CDATA[
                 CREATE FOREIGN TABLE G1 (e1 string, e2 integer);

--- a/komodo-utils/src/test/resources/org/komodo/test/utils/teiid-vdb-all-elements.xml
+++ b/komodo-utils/src/test/resources/org/komodo/test/utils/teiid-vdb-all-elements.xml
@@ -7,10 +7,13 @@
     <model name="model-one" type="PHYSICAL" visible="false">
         <description>model description</description>
         <property name="model-prop" value="model-value-override"></property>
+        <property name="origin-conn-src-s1" value="S1Connection"></property>
         <source name="s1" translator-name="translator" connection-jndi-name="java:mybinding"></source>
     </model>
     <model name="model-two" type="VIRTUAL">
         <property name="model-prop" value="model-value"></property>
+        <property name="origin-conn-src-s1" value="S1Connection"></property>
+        <property name="origin-conn-src-s2" value="S2Connection"></property>
         <source name="s1" translator-name="translator" connection-jndi-name="java:binding-one"></source>
         <source name="s2" translator-name="translator" connection-jndi-name="java:binding-two"></source>
         <metadata type="DDL"><![CDATA[

--- a/komodo-utils/src/test/resources/org/komodo/test/utils/tweet-example-vdb.xml
+++ b/komodo-utils/src/test/resources/org/komodo/test/utils/tweet-example-vdb.xml
@@ -7,6 +7,7 @@
  	<property name="UseConnectorMetadata" value="cached" />
 
     <model name="twitter" type="PHYSICAL">
+    	<property name="origin-conn-src-twitter" value="twitterConnection1"></property>
         <source name="twitter" translator-name="rest" connection-jndi-name="java:/twitterDS"/>
     </model>
     <model name="twitterview" type="VIRTUAL">

--- a/komodo-utils/src/test/resources/org/komodo/test/utils/usstates-dataservice/usstates-vdb.xml
+++ b/komodo-utils/src/test/resources/org/komodo/test/utils/usstates-dataservice/usstates-vdb.xml
@@ -14,6 +14,7 @@
 </model>
 <model name="ServiceSource" type="PHYSICAL">
 	<property name="importer.useFullSchemaName" value="false"/>
+	<property name="origin-conn-src-jdbc-connector" value="USStatesConnection"></property>
 	<source name="jdbc-connector" translator-name="h2" connection-jndi-name="java:/USStatesSource"/>
 	<metadata type="DDL">
 		<![CDATA[

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/RestVdbModelSource.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/RestVdbModelSource.java
@@ -23,7 +23,6 @@ package org.komodo.rest.relational.response;
 
 import java.net.URI;
 import java.util.Properties;
-import org.komodo.core.KomodoLexicon;
 import org.komodo.relational.connection.Connection;
 import org.komodo.relational.model.Model;
 import org.komodo.relational.vdb.ModelSource;
@@ -55,9 +54,9 @@ public final class RestVdbModelSource extends RestBasicEntity {
     public static final String TRANSLATOR_LABEL = KomodoService.protectPrefix(VdbLexicon.Source.TRANSLATOR);
 
     /**
-     * Label used to describe the associated connection
+     * Label used to describe the origin connection
      */
-    public static final String CONNECTION_LABEL = KomodoService.protectPrefix(KomodoLexicon.VdbModelSource.ASSOCIATED_CONNECTION);
+    public static final String CONNECTION_LABEL = KomodoService.protectPrefix(VdbLexicon.Source.ORIGIN_CONNECTION);
 
     /**
      * Constructor for use when deserializing
@@ -79,7 +78,7 @@ public final class RestVdbModelSource extends RestBasicEntity {
         setJndiName(source.getJndiName(uow));
         String translatorName = source.getTranslatorName(uow);
         setTranslator(translatorName);
-        Connection connection = source.getAssociatedConnection(uow);
+        Connection connection = source.getOriginConnection(uow);
         if (connection != null) {
             setConnection(connection.getAbsolutePath());
         }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
@@ -808,7 +808,7 @@ public final class KomodoDataserviceService extends KomodoService
             // If the svcModelSource has an associated connection (which it should)
             // then apply its reference to this model source as well
             //
-            Connection connection = svcModelSource.getAssociatedConnection(uow);
+            Connection connection = svcModelSource.getOriginConnection(uow);
             if (connection != null) {
                 modelSource.setAssociatedConnection(uow, connection);
             }
@@ -1167,6 +1167,15 @@ public final class KomodoDataserviceService extends KomodoService
             lhPhysicalModelSource.setJndiName(uow, lhModelSource.getJndiName(uow));
             lhPhysicalModelSource.setTranslatorName(uow, lhModelSource.getTranslatorName(uow));
             
+            //
+            // If the lhPhysicalModelSource has an associated connection (which it should)
+            // then apply its reference to this model source as well
+            //
+            Connection connection = lhPhysicalModelSource.getOriginConnection(uow);
+            if (connection != null) {
+                lhPhysicalModelSource.setAssociatedConnection(uow, connection);
+            }
+
             // --------------------------------------------------
             // Add physical model for rh modelSource
             // - (dont add duplicate if same as left)

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/unit/AbstractKomodoServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/unit/AbstractKomodoServiceTest.java
@@ -213,9 +213,11 @@ public abstract class AbstractKomodoServiceTest extends AbstractServiceTest {
         Assert.assertNotNull(serviceTestUtilities.getDataservice(USER_NAME, serviceName));
     }
 
-    protected void createConnection( String connectionName ) throws Exception {
+    protected String createConnection( String connectionName ) throws Exception {
         serviceTestUtilities.createConnection(connectionName, USER_NAME);
-        Assert.assertNotNull(serviceTestUtilities.getConnection(USER_NAME, connectionName));
+        Connection connection = serviceTestUtilities.getConnection(USER_NAME, connectionName);
+        Assert.assertNotNull(connection);
+        return connection.getAbsolutePath();
     }
 
     protected void createDriver( String driverName ) throws Exception {

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/unit/KomodoVdbServiceTestInSuite.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/unit/KomodoVdbServiceTestInSuite.java
@@ -755,6 +755,12 @@ public class KomodoVdbServiceTestInSuite extends AbstractKomodoServiceTest {
     @Test
     public void shouldGetVdbModelSource() throws Exception {
 
+        //
+        // Create the connection in the repository to ensure the model source
+        // returns an origin reference to it
+        //
+        String connectionPath = createConnection(TestUtilities.PORTFOLIO_CONNECTION_NAME);
+
         // get
         Properties settings = uriBuilder().createSettings(SettingNames.VDB_NAME, TestUtilities.PORTFOLIO_VDB_NAME);
         uriBuilder().addSetting(settings, SettingNames.VDB_PARENT_PATH, uriBuilder().workspaceVdbsUri());
@@ -774,6 +780,7 @@ public class KomodoVdbServiceTestInSuite extends AbstractKomodoServiceTest {
         assertEquals(KomodoType.VDB_MODEL_SOURCE, source.getkType());
         assertEquals("java:/excel-file", source.getJndiName());
         assertEquals("excel", source.getTranslator());
+        assertEquals(connectionPath, source.getConnection());
 
         Collection<RestLink> links = source.getLinks();
         assertEquals(3, links.size());


### PR DESCRIPTION
* This property was temporarily located in KomodoLexicon but belongs in the
  VdbLexicon and its requisite modeshape vdb prefix. Thus, it has been
  pushed down to the teiid-modeshape project.

* To be more clearer, it has been renamed to the origin connection rather
  than the associated connection.

* The property stores the name of the connection which is searched for in
  the user's workspace before being returned. This may well change in the
  future as connections are placed in a shared area.

* Change to original idea of storing the connection reference since this
  'requires' a connection to be in the repository, otherwise it will not be
  imported/exported. Better to get the property populated to ensure the
  maximum information is retained.

* pom.xml
 * Version of teiid-modeshape upgraded to bring in changes.