### PR TITLE
TEIIDTOOLS-312 support mongo source

### DIFF
--- a/komodo-core/src/test/java/org/komodo/core/visitor/TestDdlNodeVisitor.java
+++ b/komodo-core/src/test/java/org/komodo/core/visitor/TestDdlNodeVisitor.java
@@ -162,6 +162,19 @@ public class TestDdlNodeVisitor extends AbstractLocalRepositoryTest {
     }
 
     @Test(timeout = 5000000)
+    public void testForeignTable2() throws Exception {
+        String ddl = "CREATE FOREIGN TABLE G1 (" + NEW_LINE +
+                TAB + "street string," + NEW_LINE +
+                TAB + "zipcode string," + NEW_LINE +
+                TAB + "building string," + NEW_LINE +
+                TAB + "coord object[]," + NEW_LINE +
+                TAB + "test string" + NEW_LINE +
+                ") OPTIONS (\"UPDATABLE\" 'true', \"UUID\" 'uuid2');";
+
+        helpTest(ddl, ddl, SEQUENCE_DDL_PATH + "G1");
+    }
+
+    @Test(timeout = 5000000)
     public void testMultiKeyPK() throws Exception {
         String ddl = "CREATE FOREIGN TABLE G1 (" + NEW_LINE +
                 TAB + "e1 integer," + NEW_LINE +

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
@@ -94,7 +94,6 @@ import org.komodo.rest.relational.response.RestConnectionDriver;
 import org.komodo.rest.relational.response.RestDataserviceViewInfo;
 import org.komodo.rest.relational.response.RestVdb;
 import org.komodo.spi.KException;
-import org.komodo.spi.constants.ExportConstants;
 import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.lexicon.datavirt.DataVirtLexicon;
 import org.komodo.spi.lexicon.sql.teiid.TeiidSqlConstants;
@@ -789,11 +788,9 @@ public final class KomodoDataserviceService extends KomodoService
         	sourceModel.setModelType(uow, Type.PHYSICAL);
 
             // The source model DDL contains the relevant table DDL only.  This limits the source metadata which is loaded on deployment.
-            Properties exportProps = new Properties();
-            exportProps.put( ExportConstants.EXCLUDE_TABLE_CONSTRAINTS_KEY, true );
             StringBuilder sourceDdl = new StringBuilder();
             for(Table viewTable: viewTables) {
-            	byte[] bytes = viewTable.export(uow, exportProps);
+            	byte[] bytes = viewTable.export(uow, new Properties());
             	String tableDdl = new String(bytes);
             	sourceDdl.append(tableDdl);
             }
@@ -1146,13 +1143,11 @@ public final class KomodoDataserviceService extends KomodoService
             lhPhysicalModel.setModelType(uow, Type.PHYSICAL);
 
             // The source model DDL contains the table DDL only.  This limits the source metadata which is loaded on deployment.
-            Properties exportProps = new Properties();
-            exportProps.put( ExportConstants.EXCLUDE_TABLE_CONSTRAINTS_KEY, true );
             // LH Table DDL
-            byte[] bytes = lhSourceTable.export(uow, exportProps);
+            byte[] bytes = lhSourceTable.export(uow, new Properties());
             String lhTableDdl = new String(bytes);
             // RH Table DDL
-            bytes = rhSourceTable.export(uow, exportProps);
+            bytes = rhSourceTable.export(uow, new Properties());
             String rhTableDdl = new String(bytes);
             
             // If same LH and RH Model, add the RH table DDL as well


### PR DESCRIPTION
Addresses a couple issues that were found during mongo testing.
- KomodoDataserviceService - the source tables were not being exported with constraints.  The constraints are required for mongo to work properly
- ViewDdlBuilder - array types were not being handled correctly.  now using same approach as DdlNodeVisitor.
- added test cases for DdlNodeVisitor and the ViewDdlBuilder