### PR TITLE
TEIIDTOOLS-427 Adds view name validation service

### DIFF
--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
@@ -364,6 +364,16 @@ public class KomodoRestV1Application extends Application implements SystemConsta
         String SOURCE_PLACEHOLDER = "{sourceName}"; //$NON-NLS-1$
 
         /**
+         * The name of the URI path segment for the collection of views of a vdb model
+         */
+        String VIEWS_SEGMENT = "Views"; //$NON-NLS-1$
+
+        /**
+         * Placeholder added to an URI to allow a specific view id
+         */
+        String VIEW_PLACEHOLDER = "{viewName}"; //$NON-NLS-1$
+
+        /**
          * The name of the URI path segment for the collection of catalogs
          */
         String JDBC_CATALOG_SCHEMA_SEGMENT = "JdbcCatalogSchema"; //$NON-NLS-1$

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -924,6 +924,16 @@ public final class RelationalMessages {
         VDB_TO_REPO_IMPORT_ERROR,
         
         /**
+         * A message indicating that a View with the given name already exists.
+         */
+        VIEW_NAME_EXISTS,
+
+        /**
+         * A message indicating an unexpected error occurred during name validation.
+         */
+        VIEW_NAME_VALIDATION_ERROR,
+
+        /**
          * An error occurred while trying to obtain the teiid schema
          */
         SCHEMA_SERVICE_GET_SCHEMA_ERROR,

--- a/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -140,6 +140,9 @@ Error.VDB_SAMPLE_IMPORT_SUCCESS = The sample vdb %s was imported successfully
 Error.VDB_SAMPLE_IMPORT_ERRORS = Errors occurred duing the import of vdb sample %s: %s
 Error.VDB_SAMPLE_IMPORT_VDB_EXISTS = The sample vdb %s already exists so no need to import it again 
 
+Error.VIEW_NAME_EXISTS = A View with the same name already exists.
+Error.VIEW_NAME_VALIDATION_ERROR = An error occurred trying to validate the View name.
+
 Error.DATASERVICE_SERVICE_GET_DATASERVICES_ERROR = An error occurred constructing the JSON document representing the DataServices in the Komodo workspace: %s
 Error.DATASERVICE_SERVICE_GET_DATASERVICE_ERROR = An error occurred constructing the JSON document for DataService %s: %s
 Error.DATASERVICE_SERVICE_GET_CONNECTIONS_ERROR = An error occurred constructing the JSON document for the connection of DataService %s: %s

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/unit/AbstractKomodoServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/unit/AbstractKomodoServiceTest.java
@@ -235,6 +235,11 @@ public abstract class AbstractKomodoServiceTest extends AbstractServiceTest {
         Assert.assertNotNull(serviceTestUtilities.getVdbModel(USER_NAME, vdbName, modelName));
     }
 
+    protected void createVdbModelView( String vdbName, String modelName, String viewName ) throws Exception {
+        serviceTestUtilities.createVdbModelView(vdbName, modelName, viewName, USER_NAME);
+        Assert.assertNotNull(serviceTestUtilities.getVdbModelView(USER_NAME, vdbName, modelName, viewName));
+    }
+
     protected List<String> loadSampleSearches() throws Exception {
         List<String> searchNames = new ArrayList<>();
         Repository repository = restApp().getDefaultRepository();

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/unit/KomodoVdbServiceTestInSuite.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/unit/KomodoVdbServiceTestInSuite.java
@@ -1463,4 +1463,104 @@ public class KomodoVdbServiceTestInSuite extends AbstractKomodoServiceTest {
         String errorMsg = extractResponse(response);
         assertThat(errorMsg, is("")); // no error message since name was valid
     }
+
+    @Test
+    public void shouldFailViewNameValidationWhenNameAlreadyExists() throws Exception {
+    	createVdbModelView("aVdb","aModel","aView");
+
+        Properties settings = uriBuilder().createSettings(SettingNames.VDB_NAME, "aVdb");
+        uriBuilder().addSetting(settings, SettingNames.VDB_PARENT_PATH, uriBuilder().workspaceVdbsUri());
+        uriBuilder().addSetting(settings, SettingNames.MODEL_NAME, "aModel");
+        URI modelUri = uriBuilder().vdbModelUri(LinkType.SELF, settings);
+        URI uri = UriBuilder.fromUri(modelUri).path(V1Constants.VIEWS_SEGMENT).path(V1Constants.NAME_VALIDATION_SEGMENT).path("aView").build();
+        HttpGet request = request(uri, RequestType.GET, MediaType.TEXT_PLAIN_TYPE);
+        HttpResponse response = executeOk(request);
+
+        extractResponse(response);
+    }
+
+    @Test
+    public void shouldFailViewNameValidationWhenNameHasInvalidCharacters() throws Exception {
+        Properties settings = uriBuilder().createSettings(SettingNames.VDB_NAME, TestUtilities.PARTS_VDB_NAME);
+        uriBuilder().addSetting(settings, SettingNames.VDB_PARENT_PATH, uriBuilder().workspaceVdbsUri());
+        uriBuilder().addSetting(settings, SettingNames.MODEL_NAME, "PartsSS");
+        URI modelUri = uriBuilder().vdbModelUri(LinkType.SELF, settings);
+        URI uri = UriBuilder.fromUri(modelUri).path(V1Constants.VIEWS_SEGMENT).path(V1Constants.NAME_VALIDATION_SEGMENT).path("InvalidN@me").build();
+        HttpGet request = request(uri, RequestType.GET, MediaType.TEXT_PLAIN_TYPE);
+        HttpResponse response = executeOk(request);
+
+        extractResponse(response);
+    }
+
+    @Test
+    public void shouldFailViewNameValidationWhenNameIsEmpty() throws Exception {
+        Properties settings = uriBuilder().createSettings(SettingNames.VDB_NAME, TestUtilities.PARTS_VDB_NAME);
+        uriBuilder().addSetting(settings, SettingNames.VDB_PARENT_PATH, uriBuilder().workspaceVdbsUri());
+        uriBuilder().addSetting(settings, SettingNames.MODEL_NAME, "PartsSS");
+        URI modelUri = uriBuilder().vdbModelUri(LinkType.SELF, settings);
+        URI uri = UriBuilder.fromUri(modelUri).path(V1Constants.VIEWS_SEGMENT).path(V1Constants.NAME_VALIDATION_SEGMENT).path("").build();
+        HttpGet request = request(uri, RequestType.GET, MediaType.TEXT_PLAIN_TYPE);
+        HttpResponse response = execute(request);
+
+        assertResponse(response, HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        String errorMsg = extractResponse(response);
+        assertThat(errorMsg, startsWith("RESTEASY"));
+    }
+
+    @Test
+    public void shouldFailViewNameValidationWhenNameHasSpaces() throws Exception {
+        Properties settings = uriBuilder().createSettings(SettingNames.VDB_NAME, TestUtilities.PARTS_VDB_NAME);
+        uriBuilder().addSetting(settings, SettingNames.VDB_PARENT_PATH, uriBuilder().workspaceVdbsUri());
+        uriBuilder().addSetting(settings, SettingNames.MODEL_NAME, "PartsSS");
+        URI modelUri = uriBuilder().vdbModelUri(LinkType.SELF, settings);
+        URI uri = UriBuilder.fromUri(modelUri).path(V1Constants.VIEWS_SEGMENT).path(V1Constants.NAME_VALIDATION_SEGMENT).path("a b c").build();
+        HttpGet request = request(uri, RequestType.GET, MediaType.TEXT_PLAIN_TYPE);
+        HttpResponse response = executeOk(request);
+
+        String errorMsg = extractResponse(response);
+        assertThat(errorMsg, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldFailViewNameValidationWhenVdbNotFound() throws Exception {
+        Properties settings = uriBuilder().createSettings(SettingNames.VDB_NAME, "VdbNotFound");
+        uriBuilder().addSetting(settings, SettingNames.VDB_PARENT_PATH, uriBuilder().workspaceVdbsUri());
+        uriBuilder().addSetting(settings, SettingNames.MODEL_NAME, "PartsSS");
+        URI modelUri = uriBuilder().vdbModelUri(LinkType.SELF, settings);
+        URI uri = UriBuilder.fromUri(modelUri).path(V1Constants.VIEWS_SEGMENT).path(V1Constants.NAME_VALIDATION_SEGMENT).path("ValidName").build();
+        HttpGet request = request(uri, RequestType.GET, MediaType.TEXT_PLAIN_TYPE);
+        HttpResponse response = execute(request);
+
+        String errorMsg = extractResponse(response);
+        assertThat(errorMsg, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldFailViewNameValidationWhenVdbModelNotFound() throws Exception {
+        Properties settings = uriBuilder().createSettings(SettingNames.VDB_NAME, TestUtilities.PARTS_VDB_NAME);
+        uriBuilder().addSetting(settings, SettingNames.VDB_PARENT_PATH, uriBuilder().workspaceVdbsUri());
+        uriBuilder().addSetting(settings, SettingNames.MODEL_NAME, "NotFoundModel");
+        URI modelUri = uriBuilder().vdbModelUri(LinkType.SELF, settings);
+        URI uri = UriBuilder.fromUri(modelUri).path(V1Constants.VIEWS_SEGMENT).path(V1Constants.NAME_VALIDATION_SEGMENT).path("ValidName").build();
+        HttpGet request = request(uri, RequestType.GET, MediaType.TEXT_PLAIN_TYPE);
+        HttpResponse response = execute(request);
+
+        String errorMsg = extractResponse(response);
+        assertThat(errorMsg, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldValidateViewName() throws Exception {
+        Properties settings = uriBuilder().createSettings(SettingNames.VDB_NAME, TestUtilities.PARTS_VDB_NAME);
+        uriBuilder().addSetting(settings, SettingNames.VDB_PARENT_PATH, uriBuilder().workspaceVdbsUri());
+        uriBuilder().addSetting(settings, SettingNames.MODEL_NAME, "PartsSS");
+        URI modelUri = uriBuilder().vdbModelUri(LinkType.SELF, settings);
+        URI uri = UriBuilder.fromUri(modelUri).path(V1Constants.VIEWS_SEGMENT).path(V1Constants.NAME_VALIDATION_SEGMENT).path("ValidName").build();
+        HttpGet request = request(uri, RequestType.GET, MediaType.TEXT_PLAIN_TYPE);
+        HttpResponse response = executeOk(request);
+
+        String errorMsg = extractResponse(response);
+        assertThat(errorMsg, is("")); // no error message since name was valid
+    }
+    
 }


### PR DESCRIPTION
Adds a view name validation service - can be used by client to validate view names to ensure the name contains valid chars, etc.  And to verify that a view with the same name does not already exist.