### PR TITLE
TEIIDTOOLS-420: Provides API for logging in publishing operations

### DIFF
--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
@@ -627,6 +627,11 @@ public class KomodoRestV1Application extends Application implements SystemConsta
          * Publish VDB
          */
         String PUBLISH = "publish"; //$NON-NLS-1$
+
+        /**
+         * Publish VDB Logs
+         */
+        String PUBLISH_LOGS = "publishLogs"; //$NON-NLS-1$
     }
 
     private static final int TIMEOUT = 1;


### PR DESCRIPTION
* Adds REST API method to KomodoMetadataService for fetching the publishing
  logs for an individual virtualization being published.

* TeiidOpenShiftClient
 * Uses the info, error & debug functions to add logging to the main log
   file and to an additional file for the virt being published. This log
   can then be preserved by OS' storage.
 * The log file is available to be read by the REST API and returned as
   content for display in the UI.