### PR TITLE
TEIIDTOOLS-463 Adds path info to schema nodes

### DIFF
--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/connection/RestSchemaNode.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/connection/RestSchemaNode.java
@@ -47,6 +47,11 @@ public class RestSchemaNode implements KRestEntity {
     public static final String TYPE_LABEL = "type";
 
     /**
+     * Label for type
+     */
+    public static final String PATH_LABEL = "path";
+
+    /**
      * Label for queryable
      */
     public static final String QUERYABLE_LABEL = "queryable";
@@ -63,6 +68,8 @@ public class RestSchemaNode implements KRestEntity {
     private String connectionName;
 
     private String type;
+    
+    private String path;
     
     private boolean queryable = false;
 
@@ -111,6 +118,14 @@ public class RestSchemaNode implements KRestEntity {
 
     public void setType(String type) {
         this.type = type;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
     }
 
     public boolean isQueryable() {

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoConnectionService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoConnectionService.java
@@ -1506,6 +1506,8 @@ public final class KomodoConnectionService extends KomodoService {
                 	String name = getSegmentName(segments[segments.length-1]);
                 	RestSchemaNode node = new RestSchemaNode(connectionName, name, type);
                 	node.setQueryable(true);
+                	String path = createSchemaNodePath(segments.length-1, segments);
+                	node.setPath(path);
                 	parentNode.addChild(node);
                 }
             }
@@ -1540,6 +1542,8 @@ public final class KomodoConnectionService extends KomodoService {
     			// No match - create a new node
     			if(matchNode == null) {
     				matchNode = new RestSchemaNode(connectionName, name, type);
+    				String path = createSchemaNodePath(i,segments);
+    				matchNode.setPath(path);
     				currentNodes.add(matchNode);
     			}
     		    // Set parent for next iteration
@@ -1558,6 +1562,8 @@ public final class KomodoConnectionService extends KomodoService {
     			// No match - create a new node
     			if(matchNode == null) {
     				matchNode = new RestSchemaNode(connectionName, name, type);
+    				String path = createSchemaNodePath(i,segments);
+    				matchNode.setPath(path);
     				parentNode.addChild(matchNode);
     			}
     			// Set next parent if not last level
@@ -1569,6 +1575,27 @@ public final class KomodoConnectionService extends KomodoService {
     	return parentNode;
     }
 
+    /**
+     * Generate the path for the node, given the segments and the position within the segments
+     * @param iPosn the index position within the segments
+     * @param segments the array of segments
+     * @return the node path (segment0/segment1/etc)
+     */
+    private String createSchemaNodePath(int iPosn, String[] segments) {
+    	StringBuilder sb = new StringBuilder();
+    	if(segments!=null && segments.length > 0) {
+        	for (int i = 0; i < segments.length; i++) {
+        		if(i < iPosn) {
+        			sb.append(segments[i]+"/");
+        		} else {
+        			sb.append(segments[i]);
+        			break;
+        		}
+        	}
+    	}
+    	return sb.toString();
+    }
+    
     /**
      * Searches the supplied list for node with matching name and type.  Does NOT search children or parents of supplied nodes.
      * @param connectionName the connection name

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoMetadataService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoMetadataService.java
@@ -2004,11 +2004,9 @@ public class KomodoMetadataService extends KomodoService {
             
             // Get the current workspace connection VDB names
             List<String> connectionVdbNames = new ArrayList<String>();
-            KomodoObject[] allVdbObjs = wMgr.getChildrenOfType(uow, VdbLexicon.Vdb.VIRTUAL_DATABASE);
-            for( KomodoObject kObj: allVdbObjs) {
-            	if(kObj.getName(uow).endsWith("btlconn")) {
-            		connectionVdbNames.add(kObj.getName(uow));
-            	}
+            KomodoObject[] connVdbObjs = wMgr.getChildrenOfType(uow, VdbLexicon.Vdb.VIRTUAL_DATABASE, "*btlconn");
+            for( KomodoObject kObj: connVdbObjs) {
+           		connectionVdbNames.add(kObj.getName(uow));
             }
             
             // Add import for connectionVdb if it is missing


### PR DESCRIPTION
Adds path info on the schema nodes which are generated for connection schema.
- added path to the RestSchemaNode
- the createSchemaNodePath method in KomodoConnectionService generates the path.  The path is in the fqn format
- also made a minor simplification change in KomodoMetadataService for a prior issue