### PR TITLE
Fix for TEIIDTOOLS-471 Deleting a View Should Also Delete Editor State

### DIFF
--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoService.java
@@ -49,6 +49,7 @@ import org.komodo.core.repository.SynchronousCallback;
 import org.komodo.relational.connection.Connection;
 import org.komodo.relational.dataservice.Dataservice;
 import org.komodo.relational.profile.Profile;
+import org.komodo.relational.profile.ViewEditorState;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.rest.AuthHandlingFilter.OAuthCredentials;
@@ -163,6 +164,20 @@ public abstract class KomodoService implements V1Constants {
         }
     }
 
+    /**
+     * <strong>*** The result ID needs to match the format that Beetle Studio uses. ***</strong>
+     *
+     * @param vdbName the VDB the view is contained in (cannot be empty)
+     * @param viewName the view name (cannot be empty)
+     * @return the ID of the editor state of the specified view (never empty)
+     */
+    public static String getViewEditorStateId( final String vdbName,
+                                               final String viewName ) {
+        assert( !StringUtils.isBlank( vdbName ) );
+        assert( !StringUtils.isBlank( viewName ) );
+        return vdbName + '.' + viewName;
+    }
+
     protected final static SecurityPrincipal SYSTEM_USER = new SecurityPrincipal(RepositoryImpl.SYSTEM_USER, null);
     
     protected final KEngine kengine;
@@ -265,6 +280,24 @@ public abstract class KomodoService implements V1Constants {
         }
 
         return userProfile;
+    }
+
+    /**
+     * @param uow the transaction
+     * @param viewEditorStateId the editor state identifier
+     * @return <code>true</code> if editor state was deleted; <code>false</code> if not found
+     * @throws Exception if an error occurs
+     */
+    protected boolean removeEditorState(UnitOfWork uow, String viewEditorStateId) throws Exception {
+        Profile userProfile = getUserProfile(uow);
+        ViewEditorState[] states = userProfile.getViewEditorStates(uow,  viewEditorStateId);
+
+        if (states.length != 0) {
+            userProfile.removeViewEditorState(uow, viewEditorStateId);
+            return true;
+        }
+
+        return false;
     }
 
     protected String encryptSensitiveData(final HttpHeaders headers, String user, String plainText) {

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoUtilService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoUtilService.java
@@ -978,12 +978,9 @@ public final class KomodoUtilService extends KomodoService {
         try {
             uow = createTransaction(principal, "removeUserProfileViewEditorState", false); //$NON-NLS-1$
 
-            Profile userProfile = getUserProfile(uow);
-            ViewEditorState[] states = userProfile.getViewEditorStates(uow,  viewEditorStateId);
-            if (states.length == 0)
+            if (!removeEditorState(uow, viewEditorStateId)) {
                 return Response.noContent().build();
-
-            userProfile.removeViewEditorState(uow, viewEditorStateId);
+            }
 
             KomodoStatusObject kso = new KomodoStatusObject("Delete Status"); //$NON-NLS-1$
             kso.addAttribute(viewEditorStateId, "Successfully deleted"); //$NON-NLS-1$

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoVdbService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoVdbService.java
@@ -4427,6 +4427,14 @@ public final class KomodoVdbService extends KomodoService {
             KomodoStatusObject kso = new KomodoStatusObject("Delete Status"); //$NON-NLS-1$
             kso.addAttribute(viewName, "Successfully deleted"); //$NON-NLS-1$
 
+            // now delete the editor state
+            String viewEditorStateId = KomodoService.getViewEditorStateId( vdb.getName( uow ), viewName );
+
+            // if this returns false there was no editor state to delete
+            if ( removeEditorState( uow, viewEditorStateId ) ) {
+                kso.addAttribute( viewName, "Successfully deleted saved editor state" ); //$NON-NLS-1$
+            }
+
             return commit(uow, mediaTypes, kso);
         } catch (final Exception e) {
             if ((uow != null) && (uow.getState() != State.ROLLED_BACK)) {

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/ServiceTestUtilities.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/ServiceTestUtilities.java
@@ -590,6 +590,31 @@ public final class ServiceTestUtilities implements StringConstants {
         return viewEditorState;
     }
 
+    public boolean viewEditorStateExists(String user, String stateId) throws Exception {
+        UnitOfWork uow = repository.createTransaction(user, "viewEditorStateExists", true, null); //$NON-NLS-1$
+
+        try {
+            KomodoObject profileObj = repository.komodoProfile(uow);
+            assertNotNull(profileObj);
+    
+            Profile profile = new AdapterFactory().adapt(uow, profileObj, Profile.class);
+            ViewEditorState[] viewEditorStates = profile.getViewEditorStates(uow, stateId);
+    
+            if (viewEditorStates == null || viewEditorStates.length == 0)
+                return false;
+    
+            for (ViewEditorState editorState : viewEditorStates) {
+                if (editorState.getName(uow).equals(stateId)) {
+                    return true;
+                }
+            }
+    
+            return false;
+        } finally {
+            uow.commit();
+        }
+    }
+
     public void removeViewEditorState(String user, String stateId) throws Exception {
         UnitOfWork uow = repository.createTransaction(user, "Remove View Editor State", false, null); //$NON-NLS-1$
         KomodoObject profileObj = repository.komodoProfile(uow);

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/unit/KomodoVdbServiceTestInSuite.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/unit/KomodoVdbServiceTestInSuite.java
@@ -349,6 +349,42 @@ public class KomodoVdbServiceTestInSuite extends AbstractKomodoServiceTest {
     }
 
     @Test
+    public void shouldDeleteViewEditorState() throws Exception {
+        final String vdbName = "MyVdb";
+        final String modelName = "MyModel";
+        final String viewName = "MyView";
+        final String editorStateId = KomodoVdbService.getViewEditorStateId( vdbName, viewName );
+        final String newName = "theNewName";
+        final String oldName = "theOldName";
+
+        final String undoId = "UpdateViewNameCommand";
+        final Map< String, String > undoArgs = new HashMap<>();
+        undoArgs.put( "newNameKey", newName );
+        undoArgs.put( "oldNameKey", oldName );
+
+        final String redoId = "UpdateViewNameCommand";
+        final Map< String, String > redoArgs = new HashMap<>();
+        undoArgs.put( "newNameKey", oldName );
+        undoArgs.put( "oldNameKey", newName );
+
+        // setup test by creating view and view editor state
+        this.serviceTestUtilities.createVdbModelView( vdbName, modelName, viewName, USER_NAME );
+        this.serviceTestUtilities.addViewEditorState(USER_NAME, editorStateId, undoId, undoArgs, redoId, redoArgs );
+        assertThat( this.serviceTestUtilities.viewEditorStateExists( USER_NAME, editorStateId ), is( true ) );
+
+        // now test by deleting the view
+        final Properties settings = uriBuilder().createSettings( SettingNames.VDB_NAME, vdbName );
+        uriBuilder().addSetting( settings, SettingNames.VDB_PARENT_PATH, uriBuilder().workspaceVdbsUri() );
+        uriBuilder().addSetting( settings, SettingNames.MODEL_NAME, modelName );
+        uriBuilder().addSetting( settings, SettingNames.VIEW_NAME, viewName );
+
+        final URI uri = uriBuilder().vdbModelViewUri( LinkType.SELF, settings );
+        final HttpDelete request = jsonRequest( uri, RequestType.DELETE );
+        executeOk( request );
+        assertThat( this.serviceTestUtilities.viewEditorStateExists( USER_NAME, editorStateId ), is( false ) );
+    }
+
+    @Test
     public void shouldCreateVdb() throws Exception {
         String vdbName = "shouldCreateVdb";
         String description = vdbName + " VDB description";


### PR DESCRIPTION
- Moved the code that deletes the editor state to KomodoService so that it can be used by both KomodoVdbService and KomodoUtilService
- Created a method in KomodoService that provides the same editor ID used by Beetle if given a VDB name and a View name
- Created helper method in ServiceTestUtilities to check to see if a specified editor state exists
- Created test in KomodoVdbServiceTestInSuite that verifies the editor state is deleted when a view is deleted