### PR TITLE
Fixes for TEIIDTOOLS-472 and TEIIDTOOLS-473

### DIFF
--- a/komodo-relational/src/main/java/org/komodo/relational/profile/ViewEditorState.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/profile/ViewEditorState.java
@@ -21,7 +21,6 @@
  */
 package org.komodo.relational.profile;
 
-import java.util.Map;
 import org.komodo.core.KomodoLexicon;
 import org.komodo.core.repository.ObjectImpl;
 import org.komodo.relational.RelationalObject;

--- a/komodo-relational/src/main/java/org/komodo/relational/profile/internal/ProfileImpl.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/profile/internal/ProfileImpl.java
@@ -185,6 +185,11 @@ public class ProfileImpl extends RelationalObjectImpl implements Profile {
 
     @Override
     public ViewEditorState addViewEditorState(UnitOfWork transaction, String stateId) throws KException {
+        // first delete if already exists
+        if ( getViewEditorStates( transaction, stateId ).length != 0 ) {
+            removeViewEditorState( transaction, stateId );
+        }
+
         return RelationalModelFactory.createViewEditorState( transaction, getRepository(), this, stateId );
     }
 

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
@@ -74,6 +74,7 @@ import org.komodo.relational.model.Model.Type;
 import org.komodo.relational.model.PrimaryKey;
 import org.komodo.relational.model.Table;
 import org.komodo.relational.model.View;
+import org.komodo.relational.profile.ViewEditorState;
 import org.komodo.relational.resource.Driver;
 import org.komodo.relational.vdb.ModelSource;
 import org.komodo.relational.vdb.Vdb;
@@ -1678,6 +1679,8 @@ public final class KomodoDataserviceService extends KomodoService
 
             // Delete the Dataservice serviceVDB if found
             Vdb serviceVdb = dataservice.getServiceVdb(uow);
+            String vdbName = serviceVdb.getName(uow);
+
             if(serviceVdb!=null) {
                 wkspMgr.delete(uow, serviceVdb);
             }
@@ -1687,6 +1690,18 @@ public final class KomodoDataserviceService extends KomodoService
             
             KomodoStatusObject kso = new KomodoStatusObject("Delete Status"); //$NON-NLS-1$
             kso.addAttribute(dataserviceName, "Successfully deleted"); //$NON-NLS-1$
+
+            // delete any view editor states of that virtualization
+            final String viewEditorIdPrefix = KomodoService.getViewEditorStateIdPrefix( vdbName ) + "*";
+            final ViewEditorState[] editorStates = getViewEditorStates(uow, viewEditorIdPrefix);
+
+            if ( editorStates.length != 0 ) {
+                for ( final ViewEditorState editorState : editorStates ) {
+                    removeEditorState( uow, editorState );
+                }
+
+                kso.addAttribute( vdbName, "Successfully deleted " + editorStates.length + " saved editor states" ); //$NON-NLS-1$  //$NON-NLS-2$
+            }
 
             return commit(uow, mediaTypes, kso);
         } catch (final Exception e) {

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoUtilService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoUtilService.java
@@ -722,15 +722,8 @@ public final class KomodoUtilService extends KomodoService {
             // find view editor states
             final String txId = "getViewEditorStates"; //$NON-NLS-1$ //$NON-NLS-2$
             uow = createTransaction(principal, txId, true );
-            Profile profile = getUserProfile(uow);
-            ViewEditorState[] viewEditorStates = null;
 
-            if ( StringUtils.isBlank( searchPattern ) ) {
-                viewEditorStates = profile.getViewEditorStates(uow);
-            } else {
-                viewEditorStates = profile.getViewEditorStates(uow, searchPattern);
-            }
-
+            final ViewEditorState[] viewEditorStates = getViewEditorStates(uow, searchPattern);
             LOGGER.debug( "getViewEditorStates:found '{0}' ViewEditorStates", viewEditorStates.length ); //$NON-NLS-1$
 
             int start = 0;

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/ServiceTestUtilities.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/ServiceTestUtilities.java
@@ -590,8 +590,9 @@ public final class ServiceTestUtilities implements StringConstants {
         return viewEditorState;
     }
 
-    public boolean viewEditorStateExists(String user, String stateId) throws Exception {
-        UnitOfWork uow = repository.createTransaction(user, "viewEditorStateExists", true, null); //$NON-NLS-1$
+    public ViewEditorState getViewEditorState( final String user,
+                                               final String stateId ) throws Exception {
+        UnitOfWork uow = repository.createTransaction(user, "getViewEditorState", true, null); //$NON-NLS-1$
 
         try {
             KomodoObject profileObj = repository.komodoProfile(uow);
@@ -601,18 +602,22 @@ public final class ServiceTestUtilities implements StringConstants {
             ViewEditorState[] viewEditorStates = profile.getViewEditorStates(uow, stateId);
     
             if (viewEditorStates == null || viewEditorStates.length == 0)
-                return false;
+                return null;
     
             for (ViewEditorState editorState : viewEditorStates) {
                 if (editorState.getName(uow).equals(stateId)) {
-                    return true;
+                    return editorState;
                 }
             }
     
-            return false;
+            return null;
         } finally {
             uow.commit();
         }
+    }
+
+    public boolean viewEditorStateExists(String user, String stateId) throws Exception {
+        return getViewEditorState(user, stateId) != null;
     }
 
     public void removeViewEditorState(String user, String stateId) throws Exception {


### PR DESCRIPTION
- previous view editor state is deleted now before adding a new editor state
- when a virtualization is deleted all the editor states of it's views are also deleted
- added test cases