### PR TITLE
Resolve issues with ViewEditorState Rest returns with ViewDefinitions

### DIFF
--- a/komodo-core/src/main/resources/config/komodo.cnd
+++ b/komodo-core/src/main/resources/config/komodo.cnd
@@ -248,7 +248,7 @@
 [tko:viewDefinition] > nt:unstructured
   - tko:viewName (string)
   - tko:description (string)
-  - tko:isComplete (boolean) = 'false' mandatory
+  - tko:isComplete (boolean) = 'false' mandatory autocreated
   - tko:sourcePaths (string) multiple
   + tko:sqlCompositions (tko:sqlCompositions)
 
@@ -257,6 +257,7 @@
  */
 [tko:viewEditorState] > nt:unstructured
   + * (tko:stateCommandAggregate) copy
+  + tko:viewDefinition (tko:viewDefinition)
 
 [tko:viewEditorStates] > nt:unstructured
   + * (tko:viewEditorState) copy

--- a/komodo-relational/src/main/java/org/komodo/relational/RelationalModelFactory.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/RelationalModelFactory.java
@@ -1750,11 +1750,13 @@ public final class RelationalModelFactory {
        ArgCheck.isNotNull( repository, "repository" ); //$NON-NLS-1$
 
        try {
-           final KomodoObject grouping = RepositoryTools.findOrCreateChild( transaction,
-                                                                            viewEditorState,
-                                                                            KomodoLexicon.ViewEditorState.VIEW_DEFINITION,
-                                                                            KomodoLexicon.ViewEditorState.VIEW_DEFINITION );
-           final KomodoObject kobject = grouping.addChild( transaction, "viewDefinition", KomodoLexicon.ViewDefinition.NODE_TYPE );
+   		   // If a ViewDefinition already exists, remove it first
+           final ViewDefinition viewDefn = viewEditorState.getViewDefinition(transaction);
+           if (viewDefn != null) {
+           	viewDefn.remove(transaction);
+           }
+
+    	   final KomodoObject kobject = viewEditorState.addChild(transaction, KomodoLexicon.ViewEditorState.VIEW_DEFINITION, KomodoLexicon.ViewEditorState.VIEW_DEFINITION);
            final ViewDefinition result = new ViewDefinitionImpl( transaction, repository, kobject.getAbsolutePath() );
            return result;
        } catch ( final Exception e ) {
@@ -1786,9 +1788,10 @@ public final class RelationalModelFactory {
    * @throws KException
    *        if an error occurs
    */
-	public static SqlComposition createSqlComposition(UnitOfWork transaction, Repository repository,
-			ViewDefinition viewDefinition, String compositionName, String description, String leftSourcePath,
-			String rightSourcePath, String type, String operator) throws KException {
+	public static SqlComposition createSqlComposition(UnitOfWork transaction, 
+			                                          Repository repository, 
+			                                          ViewDefinition viewDefinition, 
+			                                          String compositionName) throws KException {
 		
 	       ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
 	       ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
@@ -1796,10 +1799,8 @@ public final class RelationalModelFactory {
 	       ArgCheck.isNotNull( compositionName, "compositionName" ); //$NON-NLS-1$
 	       
 	       try {
-	           final KomodoObject grouping = RepositoryTools.findOrCreateChild( transaction,
-	        		   viewDefinition,
-	                                                                            KomodoLexicon.ViewDefinition.SQL_COMPOSITIONS,
-	                                                                            KomodoLexicon.ViewDefinition.SQL_COMPOSITIONS );
+	           final KomodoObject grouping = RepositoryTools.findOrCreateChild( transaction, viewDefinition, KomodoLexicon.ViewDefinition.SQL_COMPOSITIONS,
+	                                                                                                         KomodoLexicon.ViewDefinition.SQL_COMPOSITIONS );
 	           final KomodoObject kobject = grouping.addChild( transaction, compositionName, KomodoLexicon.SqlComposition.NODE_TYPE );
 	           final SqlComposition result = new SqlCompositionImpl( transaction, repository, kobject.getAbsolutePath() );
 	           return result;

--- a/komodo-relational/src/main/java/org/komodo/relational/dataservice/Dataservice.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/dataservice/Dataservice.java
@@ -181,11 +181,11 @@ public interface Dataservice extends Exportable, RelationalObject, VdbEntryConta
      * @param uow
      *        the transaction (cannot be <code>null</code> or have a state that is not
      *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
-     * @return the names of the dataservice views (may be empty if not found)
+     * @return the names of the ViewDefinitions for the dataservice (may be empty if not found)
      * @throws KException
      *         if an error occurs
      */
-    String[] getServiceViewNames( UnitOfWork uow ) throws KException;
+    String[] getViewDefinitionNames( UnitOfWork uow ) throws KException;
 
     /**
      * @param uow

--- a/komodo-relational/src/main/java/org/komodo/relational/profile/ViewDefinition.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/profile/ViewDefinition.java
@@ -107,28 +107,11 @@ public interface ViewDefinition  extends RelationalObject, StringConstants {
      *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
      * @param compositionName
      *        the name of the sql composition being added (cannot be empty)
-     * @param description
-     *        the description of this sql composition
-     * @param leftSourcePath
-     *        the path to the left source table
-     * @param rightSourcePath
-     *        the path to the right source table
-     * @param leftColumnCriteria
-     *        the path to the left column criteria
-     * @param rightColumnCriteria
-     *        the path to the right column criteria
-     * @param type
-     *        the composition type (i.e 'INNER_JOIN', 'LEFT_JOIN', 'RIGHT_JOIN', 'FULL_OUTER_JOIN', 'UNION')
-     * @param operator
-     *        the criteria operator type (i.e 'EQ', 'NE', 'LT', 'GT', 'LE', 'GE' )
      * @return the new sql composition (never <code>null</code>)
      * @throws KException
      *         if an error occurs
      */
-    SqlComposition addSqlComposition( final UnitOfWork transaction, String compositionName, String description, 
-                                    String leftSourcePath, String rightSourcePath, 
-                                    String leftColumnCriteria, String rightColumnCriteria, 
-                                    String type, String operator ) throws KException;
+    SqlComposition addSqlComposition( final UnitOfWork transaction, String compositionName ) throws KException;
     
     /**
      * @param transaction

--- a/komodo-relational/src/main/java/org/komodo/relational/profile/ViewEditorState.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/profile/ViewEditorState.java
@@ -132,7 +132,7 @@ public interface ViewEditorState extends RelationalObject, StringConstants {
      * @throws KException
      *         if an error occurs
      */
-    ViewDefinition setViewDefinition(final UnitOfWork transaction, ViewDefinition viewDefinition) throws KException;
+    ViewDefinition setViewDefinition(final UnitOfWork transaction) throws KException;
     
     /**
      * @param transaction

--- a/komodo-relational/src/main/java/org/komodo/relational/profile/internal/SqlCompositionImpl.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/profile/internal/SqlCompositionImpl.java
@@ -99,7 +99,7 @@ public class SqlCompositionImpl  extends RelationalObjectImpl implements SqlComp
 
 	@Override
 	public void setDescription(UnitOfWork transaction, String description) throws KException {
-		setObjectProperty(transaction, "setDescription", KomodoLexicon.SqlComposition.OPERATOR, description); //$NON-NLS-1$
+		setObjectProperty(transaction, "setDescription", KomodoLexicon.SqlComposition.DESCRIPTION, description); //$NON-NLS-1$
 	}
 
 	@Override
@@ -112,7 +112,7 @@ public class SqlCompositionImpl  extends RelationalObjectImpl implements SqlComp
 
 	@Override
 	public void setLeftSourcePath(UnitOfWork transaction, String leftSourcePath) throws KException {
-		setObjectProperty(transaction, "setLeftSourcePath", KomodoLexicon.SqlComposition.OPERATOR, leftSourcePath); //$NON-NLS-1$
+		setObjectProperty(transaction, "setLeftSourcePath", KomodoLexicon.SqlComposition.LEFT_SOURCE_PATH, leftSourcePath); //$NON-NLS-1$
 	}
 
 	@Override
@@ -125,7 +125,7 @@ public class SqlCompositionImpl  extends RelationalObjectImpl implements SqlComp
 
 	@Override
 	public void setRightSourcePath(UnitOfWork transaction, String rightSourcePath) throws KException {
-		setObjectProperty(transaction, "setRightSourcePath", KomodoLexicon.SqlComposition.OPERATOR, rightSourcePath); //$NON-NLS-1$
+		setObjectProperty(transaction, "setRightSourcePath", KomodoLexicon.SqlComposition.RIGHT_SOURCE_PATH, rightSourcePath); //$NON-NLS-1$
 	}
 
 	@Override
@@ -138,7 +138,7 @@ public class SqlCompositionImpl  extends RelationalObjectImpl implements SqlComp
 
 	@Override
 	public void setType(UnitOfWork transaction, String type) throws KException {
-		setObjectProperty(transaction, "setType", KomodoLexicon.SqlComposition.OPERATOR, type); //$NON-NLS-1$
+		setObjectProperty(transaction, "setType", KomodoLexicon.SqlComposition.TYPE, type); //$NON-NLS-1$
 	}
 
 	@Override
@@ -164,7 +164,7 @@ public class SqlCompositionImpl  extends RelationalObjectImpl implements SqlComp
 
 	@Override
 	public void setLeftCriteriaColumn(UnitOfWork transaction, String leftCriteriaColumn) throws KException {
-		setObjectProperty(transaction, "setLeftCriteriaColumn", KomodoLexicon.SqlComposition.OPERATOR, leftCriteriaColumn); //$NON-NLS-1$
+		setObjectProperty(transaction, "setLeftCriteriaColumn", KomodoLexicon.SqlComposition.LEFT_CRITERIA_COLUMN, leftCriteriaColumn); //$NON-NLS-1$
 	}
 
 	@Override
@@ -177,7 +177,7 @@ public class SqlCompositionImpl  extends RelationalObjectImpl implements SqlComp
 
 	@Override
 	public void setRightCriteriaColumn(UnitOfWork transaction, String rightCriteriaColumn) throws KException {
-		setObjectProperty(transaction, "setRightCriteriaColumn", KomodoLexicon.SqlComposition.OPERATOR, rightCriteriaColumn); //$NON-NLS-1$
+		setObjectProperty(transaction, "setRightCriteriaColumn", KomodoLexicon.SqlComposition.RIGHT_CRITERIA_COLUMN, rightCriteriaColumn); //$NON-NLS-1$
 	}
 
 	@Override

--- a/komodo-relational/src/main/java/org/komodo/relational/profile/internal/ViewDefinitionImpl.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/profile/internal/ViewDefinitionImpl.java
@@ -110,16 +110,12 @@ public class ViewDefinitionImpl extends RelationalObjectImpl implements ViewDefi
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.relational.profile.ViewDefinition#addSqlComposition(UnitOfWork, String, String, String, String, String, String, String, String)
+     * @see org.komodo.relational.profile.ViewDefinition#addSqlComposition(UnitOfWork, String)
      */
 	@Override
-	public SqlComposition addSqlComposition(UnitOfWork transaction, String compositionName, String description,
-			String leftSourcePath, String rightSourcePath, 
-            String leftColumnCriteria, String rightColumnCriteria, 
-            String type, String operator) throws KException {
-		// TODO Auto-generated method stub
-		return RelationalModelFactory.createSqlComposition( transaction, getRepository(), this, 
-				compositionName, description, leftSourcePath, rightSourcePath, type, operator);
+	public SqlComposition addSqlComposition(UnitOfWork transaction, 
+			                                String compositionName) throws KException {
+		return RelationalModelFactory.createSqlComposition( transaction, getRepository(), this, compositionName);
 	}
     
     private KomodoObject getSqlCompositionsGroupingNode( final UnitOfWork transaction ) {
@@ -315,7 +311,7 @@ public class ViewDefinitionImpl extends RelationalObjectImpl implements ViewDefi
 
 	@Override
 	public void setComplete(UnitOfWork transaction, boolean complete) throws KException {
-		setObjectProperty( transaction, "setDescription", KomodoLexicon.ViewDefinition.DESCRIPTION, complete ); //$NON-NLS-1$
+		setObjectProperty( transaction, "setComplete", KomodoLexicon.ViewDefinition.IS_COMPLETE, complete ); //$NON-NLS-1$
 	}
 
 	@Override
@@ -323,8 +319,9 @@ public class ViewDefinitionImpl extends RelationalObjectImpl implements ViewDefi
         ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
         ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
         
-        String value = getObjectProperty(transaction, PropertyValueType.BOOLEAN, "isComplete", //$NON-NLS-1$
-                KomodoLexicon.ViewDefinition.IS_COMPLETE );
-		return Boolean.getBoolean(value);
+        final Boolean value = getObjectProperty(transaction, PropertyValueType.BOOLEAN, "isComplete", //$NON-NLS-1$
+                                                             KomodoLexicon.ViewDefinition.IS_COMPLETE );
+		return value;
 	}
+
 }

--- a/komodo-relational/src/main/java/org/komodo/relational/profile/internal/ViewEditorStateImpl.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/profile/internal/ViewEditorStateImpl.java
@@ -24,7 +24,9 @@ package org.komodo.relational.profile.internal;
 import java.util.ArrayList;
 import java.util.List;
 import org.komodo.core.KomodoLexicon;
+import org.komodo.relational.Messages;
 import org.komodo.relational.RelationalModelFactory;
+import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.internal.RelationalObjectImpl;
 import org.komodo.relational.profile.Profile;
 import org.komodo.relational.profile.StateCommandAggregate;
@@ -115,7 +117,7 @@ public class ViewEditorStateImpl extends RelationalObjectImpl implements ViewEdi
     @Override
     public StateCommandAggregate[] getCommands(UnitOfWork transaction) throws KException {
         KomodoObject[] commands = getChildrenOfType(transaction,
-                                                                                                        KomodoLexicon.StateCommandAggregate.NODE_TYPE);
+                                                    KomodoLexicon.StateCommandAggregate.NODE_TYPE);
         if (commands == null)
             return StateCommandAggregate.NO_STATE_COMMAND_AGGREGATES;
 
@@ -129,20 +131,19 @@ public class ViewEditorStateImpl extends RelationalObjectImpl implements ViewEdi
     
 
 	@Override
-	public ViewDefinition setViewDefinition(UnitOfWork transaction, ViewDefinition viewDefinition) throws KException {
-		// TODO Auto-generated method stub
-		return null;
+	public ViewDefinition setViewDefinition(UnitOfWork transaction) throws KException {
+        // Create the a new ViewDefinition
+        return RelationalModelFactory.createViewDefinition(transaction, getRepository(), this);
 	}
 
 	@Override
 	public ViewDefinition getViewDefinition(UnitOfWork transaction) throws KException {
-        KomodoObject[] viewDefs = getChildrenOfType(transaction,
-                KomodoLexicon.ViewDefinition.NODE_TYPE);
-			if (viewDefs == null || viewDefs.length == 0)
-				return null;
-			
-			KomodoObject ko = viewDefs[0];
-			return new ViewDefinitionImpl(transaction, getRepository(), ko.getAbsolutePath());
+		KomodoObject[] viewDefs = getChildrenOfType(transaction, KomodoLexicon.ViewDefinition.NODE_TYPE);
+		if (viewDefs == null || viewDefs.length == 0) {
+			return null;
+		}
+
+		return new ViewDefinitionImpl(transaction, getRepository(), viewDefs[0].getAbsolutePath());
 	}
 
 }

--- a/komodo-relational/src/test/java/org/komodo/relational/dataservice/internal/DataserviceImplTest.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/dataservice/internal/DataserviceImplTest.java
@@ -579,14 +579,7 @@ public final class DataserviceImplTest extends RelationalModelTest {
         final Model virtualModel = serviceVdb.addModel( getTransaction(), serviceViewModel );
         virtualModel.setModelType( getTransaction(), Model.Type.VIRTUAL );
 
-        // Add a view to the virtual model
-        final String serviceView1 = "serviceView1";
-        final String serviceView2 = "serviceView2";
-        virtualModel.addView( getTransaction(), serviceView1 );
-        virtualModel.addView( getTransaction(), serviceView2 );
-        final String[] serviceViews = new String[2];
-        serviceViews[0] = serviceView1;
-        serviceViews[1] = serviceView2;
+        final String[] serviceViews = new String[0];
 
         commit(); // need this so that VDB will be found by query that sets reference
 
@@ -597,7 +590,7 @@ public final class DataserviceImplTest extends RelationalModelTest {
         assertThat( this.dataservice.getServiceVdbEntry( getTransaction() ).getName( getTransaction() ), is( name ) );
         assertThat( this.dataservice.getServiceVdb( getTransaction() ), is( notNullValue() ) );
         assertThat( this.dataservice.getServiceViewModelName( getTransaction() ), is( serviceViewModel ) );
-        assertThat( this.dataservice.getServiceViewNames( getTransaction() ), is( serviceViews ) );
+        assertThat( this.dataservice.getViewDefinitionNames( getTransaction() ), is( serviceViews ) );
     }
 
     @Test

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -1520,9 +1520,24 @@ public final class RelationalMessages {
         PROFILE_EDITOR_STATE_MISSING_ID,
 
         /**
-         * An error indicating a profile view editor state is missing its content
+         * An error indicating a profile view editor state is missing commands
          */
-        PROFILE_EDITOR_STATE_MISSING_CONTENT,
+        PROFILE_EDITOR_STATE_MISSING_COMMANDS,
+
+        /**
+         * An error indicating a profile view editor state is missing its view definition
+         */
+        PROFILE_EDITOR_STATE_MISSING_VIEW_DEFINITION,
+
+        /**
+         * An error indicating a problem with getting a view editor state
+         */
+        PROFILE_EDITOR_STATE_GET_ERROR,
+        
+        /**
+         * An error indicating a problem with getting view editor states
+         */
+        PROFILE_EDITOR_STATES_GET_ERROR,
 
         /**
          * An error indicating a problem with creating a view editor state

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/dataservice/RestDataservice.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/dataservice/RestDataservice.java
@@ -60,7 +60,7 @@ public final class RestDataservice extends RestBasicEntity {
     /**
      * Label used to describe dataservice viewNames
      */
-    public static final String DATASERVICE_VIEWS_LABEL = "serviceViews"; //$NON-NLS-1$
+    public static final String DATASERVICE_VIEW_DEFINITIONS_LABEL = "serviceViewDefinitions"; //$NON-NLS-1$
 
     /**
      * Label used to describe dataservice vdbName
@@ -81,11 +81,6 @@ public final class RestDataservice extends RestBasicEntity {
      * Label used to describe dataservice connection total
      */
     public static final String DATASERVICE_CONNECTION_TOTAL_LABEL = "connections"; //$NON-NLS-1$
-
-    /**
-     * Label used to describe service view table names
-     */
-    public static final String DATASERVICE_VIEW_TABLES_LABEL = "serviceViewTables"; //$NON-NLS-1$
 
     /**
      * fqn table option key
@@ -130,29 +125,7 @@ public final class RestDataservice extends RestBasicEntity {
             setServiceVdbName(serviceVdb.getVdbName( uow ));
             setServiceVdbVersion(Integer.toString(serviceVdb.getVersion( uow )));
             setServiceViewModel(dataService.getServiceViewModelName(uow));
-            setServiceViewNames(dataService.getServiceViewNames(uow));
-            
-            // Get the current tables from source models
-            List<String> tableNames = new ArrayList<String>();
-            Model[] models = serviceVdb.getModels(uow);
-            if(models!=null) {
-                for(Model model : models) {
-                    if(model.getModelType(uow) == Model.Type.PHYSICAL) {
-                        Table[] tables = model.getTables(uow);
-                        for(Table table : tables) {
-                    		// 'tableNames' are generated using the fqn table option, if available.
-                            final String tableFqn = OptionContainerUtils.getOption( uow, table, TABLE_OPTION_FQN );
-                            if (tableFqn != null && tableFqn.length()>0) {
-                                final String mdlName = model.getName(uow);
-                                final int endIndex = mdlName.indexOf(SCHEMA_MODEL_SUFFIX);
-                                final String connName = mdlName.substring(0, endIndex);
-                                tableNames.add("connection="+connName+"/"+tableFqn); //$NON-NLS-1$
-                            }
-                        }
-                    }
-                }
-            }
-            setServiceViewTables(tableNames.toArray(new String[0]));
+            setViewDefinitionNames(dataService.getViewDefinitionNames(uow));
         }
 
         Connection[] connections = dataService.getConnections(uow);
@@ -199,17 +172,17 @@ public final class RestDataservice extends RestBasicEntity {
     }
 
     /**
-     * @return the service view name (can be empty)
+     * @return the service ViewDefinition names (can be empty)
      */
-    public String[] getServiceViewNames() {
-        return (String[])tuples.get(DATASERVICE_VIEWS_LABEL);
+    public String[] getViewDefinitionNames() {
+        return (String[])tuples.get(DATASERVICE_VIEW_DEFINITIONS_LABEL);
     }
 
     /**
-     * @param viewNames the service view names to set
+     * @param viewDefinitionNames the service view names to set
      */
-    public void setServiceViewNames(final String[] viewNames) {
-        tuples.put(DATASERVICE_VIEWS_LABEL, viewNames);
+    public void setViewDefinitionNames(final String[] viewDefinitionNames) {
+        tuples.put(DATASERVICE_VIEW_DEFINITIONS_LABEL, viewDefinitionNames);
     }
 
     /**
@@ -270,21 +243,6 @@ public final class RestDataservice extends RestBasicEntity {
      */
     public void setDriverTotal(int total) {
         tuples.put(DATASERVICE_DRIVER_TOTAL_LABEL, total);
-    }
-    
-    /**
-     * @return the view table names (can be <code>null</code>)
-     */
-    public String[] getServiceViewTables( ) {
-        return (String[])tuples.get(DATASERVICE_VIEW_TABLES_LABEL);
-    }
-    
-    /**
-     * @param tableNames
-     *        the view table names (can be <code>null</code>)
-     */
-    public void setServiceViewTables( final String[] tableNames ) {
-        tuples.put(DATASERVICE_VIEW_TABLES_LABEL, tableNames);
     }
     
 }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/KomodoJsonMarshaller.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/KomodoJsonMarshaller.java
@@ -169,6 +169,7 @@ public final class KomodoJsonMarshaller {
                                                   .registerTypeAdapter(RestGitRepository.class, new GitRepositorySerializer())
                                                   .registerTypeAdapter(RestViewEditorState.class, new ViewEditorStateSerializer())
                                                   .registerTypeAdapter(RestViewDefinition.class, new ViewDefinitionSerializer())
+                                                  .registerTypeAdapter(RestSqlComposition.class, new SqlCompositionSerializer())
                                                   .registerTypeAdapter(RestStateCommandAggregate.class, new ViewEditorStateCommandSerializer())
                                                   .registerTypeAdapter(RestStateCommand.class, new ViewEditorStateCmdUnitSerializer())
                                                   .registerTypeAdapter(RestVirtualizationStatus.class, new VirtualizationStatusSerializer())

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/SqlCompositionSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/SqlCompositionSerializer.java
@@ -1,0 +1,118 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational.json;
+
+import static org.komodo.rest.Messages.Error.UNEXPECTED_JSON_TOKEN;
+
+import java.io.IOException;
+
+import org.komodo.rest.Messages;
+import org.komodo.rest.relational.response.vieweditorstate.RestSqlComposition;
+import org.komodo.rest.relational.response.vieweditorstate.RestViewEditorState;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+
+
+public class SqlCompositionSerializer extends TypeAdapter<RestSqlComposition> {
+
+	@Override
+	public void write(JsonWriter out, RestSqlComposition restSqlComposition) throws IOException {
+		out.beginObject();
+		
+        out.name(RestViewEditorState.ID_NAME);
+        out.value((String)restSqlComposition.getTuples().get(RestViewEditorState.ID_NAME));
+
+        out.name(RestViewEditorState.ID_DESCRIPTION);
+        out.value((String)restSqlComposition.getTuples().get(RestViewEditorState.DESCRIPTION));
+
+        out.name(RestViewEditorState.LEFT_SOURCE_PATH_LABEL);
+        out.value(restSqlComposition.getLeftSourcePath());
+        
+        out.name(RestViewEditorState.RIGHT_SOURCE_PATH_LABEL);
+        out.value(restSqlComposition.getRightSourcePath());
+        
+        out.name(RestViewEditorState.LEFT_CRITERIA_COLUMN_LABEL);
+        out.value(restSqlComposition.getLeftCriteriaColumn());
+        
+        out.name(RestViewEditorState.RIGHT_CRITERIA_COLUMN_LABEL);
+        out.value(restSqlComposition.getRightCriteriaColumn());
+        
+        out.name(RestViewEditorState.TYPE_LABEL);
+        out.value(restSqlComposition.getType());
+        
+        out.name(RestViewEditorState.OPERATOR_LABEL);
+        out.value(restSqlComposition.getOperator());
+		
+        out.endObject();
+	}
+
+	@Override
+	public RestSqlComposition read(JsonReader in) throws IOException {
+		RestSqlComposition sqlComp = new RestSqlComposition();
+		
+		in.beginObject();
+		
+
+        while ( in.hasNext() ) {
+            final String name = in.nextName();
+
+            switch ( name ) {
+                case RestViewEditorState.ID_NAME:
+                	sqlComp.setName(in.nextString());
+                    break;
+                case RestViewEditorState.ID_DESCRIPTION:
+                	sqlComp.setDescription(in.nextString());
+                    break;
+                case RestViewEditorState.LEFT_SOURCE_PATH_LABEL:
+                	sqlComp.setLeftSourcePath(in.nextString());
+                    break;
+                case RestViewEditorState.RIGHT_SOURCE_PATH_LABEL:
+                	sqlComp.setRightSourcePath(in.nextString());
+                    break;
+                case RestViewEditorState.LEFT_CRITERIA_COLUMN_LABEL:
+                	sqlComp.setLeftCriteriaColumn(in.nextString());
+                    break;
+                case RestViewEditorState.RIGHT_CRITERIA_COLUMN_LABEL:
+                	sqlComp.setRightCriteriaColumn(in.nextString());
+                    break;
+                case RestViewEditorState.TYPE_LABEL:
+                	sqlComp.setType(in.nextString());
+                    break;
+                case RestViewEditorState.OPERATOR_LABEL:
+                	sqlComp.setOperator(in.nextString());
+                    break;
+                default: {
+                    throw new IOException( Messages.getString( UNEXPECTED_JSON_TOKEN, name ));
+                }
+            }
+        }
+
+        in.endObject();
+		
+		return sqlComp;
+	}
+
+
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/ViewDefinitionSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/ViewDefinitionSerializer.java
@@ -43,8 +43,10 @@ public class ViewDefinitionSerializer extends TypeAdapter<RestViewDefinition> {
 	public void write(JsonWriter out, RestViewDefinition restViewDef) throws IOException {
 		out.beginObject();
 		
-		out.name(RestViewEditorState.BASE_URI);
-		out.value(restViewDef.getBaseUri().toString());
+		if( restViewDef.getBaseUri() != null) {
+			out.name(RestViewEditorState.BASE_URI);
+			out.value(restViewDef.getBaseUri().toString());
+		}
 		
 		out.name(RestViewEditorState.ID_VIEW_NAME);
 		out.value(restViewDef.getViewName());
@@ -54,7 +56,7 @@ public class ViewDefinitionSerializer extends TypeAdapter<RestViewDefinition> {
 		}
 		
 		out.name(RestViewEditorState.IS_COMPLETE);
-		out.value(Boolean.toString(restViewDef.isComplete()));
+		out.value(restViewDef.isComplete());
 		
 		if( restViewDef.getSourcePaths() != null ) {
 			out.name(RestViewEditorState.SOURCE_PATHS);
@@ -71,27 +73,7 @@ public class ViewDefinitionSerializer extends TypeAdapter<RestViewDefinition> {
         	out.name(RestViewEditorState.COMPOSITIONS_LABEL);
         	out.beginArray();
         	for( RestSqlComposition comp : comps) {
-//        		BUILDER.getAdapter(RestSqlComposition.class).write(out, comp);
-                out.beginObject();
-
-                out.name(RestViewEditorState.ID_NAME);
-                out.value((String)comp.getTuples().get(RestViewEditorState.ID_NAME));
-                out.name(RestViewEditorState.ID_DESCRIPTION);
-                out.value((String)comp.getTuples().get(RestViewEditorState.DESCRIPTION));
-                out.name(RestViewEditorState.LEFT_SOURCE_PATH_LABEL);
-                out.value(comp.getLeftSourcePath());
-                out.name(RestViewEditorState.RIGHT_SOURCE_PATH_LABEL);
-                out.value(comp.getRightSourcePath());
-                out.name(RestViewEditorState.LEFT_CRITERIA_COLUMN_LABEL);
-                out.value(comp.getLeftCriteriaColumn());
-                out.name(RestViewEditorState.RIGHT_CRITERIA_COLUMN_LABEL);
-                out.value(comp.getRightCriteriaColumn());
-                out.name(RestViewEditorState.TYPE_LABEL);
-                out.value(comp.getType());
-                out.name(RestViewEditorState.OPERATOR_LABEL);
-                out.value(comp.getOperator());
-
-                out.endObject();
+        		BUILDER.getAdapter(RestSqlComposition.class).write(out, comp);
         	}
         	out.endArray();
         }
@@ -120,8 +102,7 @@ public class ViewDefinitionSerializer extends TypeAdapter<RestViewDefinition> {
                     viewDef.setSourcePaths(sourcePaths);
                     break;
                 case RestViewEditorState.IS_COMPLETE:
-                    String strValue = in.nextString();
-                    viewDef.setComplete(Boolean.parseBoolean(strValue));
+                    viewDef.setComplete(in.nextBoolean());
                     break;
                 case RestViewEditorState.COMPOSITIONS_LABEL:
                     RestSqlComposition[] comps = BUILDER.fromJson(in, RestSqlComposition[].class);

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestSqlComposition.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestSqlComposition.java
@@ -169,6 +169,30 @@ public class RestSqlComposition extends RestBasicEntity {
     
     
     /**
+     * @param name value
+     *        the new name (can be empty)
+     */
+    public void setName(final String name) {
+        tuples.put(RestViewEditorState.ID, name);
+    }
+
+    /**
+     * @return the name (can be empty)
+     */
+    public String getName() {
+        Object value = tuples.get(RestViewEditorState.ID);
+        return value != null ? value.toString() : null;
+    }
+    
+    /**
+     * @param descr value
+     *        the new description (can be empty)
+     */
+    public void setDescription(final String descr) {
+        tuples.put(RestViewEditorState.DESCRIPTION, descr);
+    }
+
+    /**
      * @return the left node path (can be empty)
      */
     public String getDescription() {
@@ -176,6 +200,14 @@ public class RestSqlComposition extends RestBasicEntity {
         return value != null ? value.toString() : null;
     }
     
+    /**
+     * @param path value
+     *        the new left source path (can be empty)
+     */
+    public void setLeftSourcePath(final String path) {
+        tuples.put(RestViewEditorState.LEFT_SOURCE_PATH_LABEL, path);
+    }
+
     /**
      * @return the left source path (can be empty)
      */
@@ -185,11 +217,27 @@ public class RestSqlComposition extends RestBasicEntity {
     }
     
     /**
+     * @param path value
+     *        the new right source path (can be empty)
+     */
+    public void setRightSourcePath(final String path) {
+        tuples.put(RestViewEditorState.RIGHT_SOURCE_PATH_LABEL, path);
+    }
+
+    /**
      * @return the right source path (can be empty)
      */
     public String getRightSourcePath() {
         Object value = tuples.get(RestViewEditorState.RIGHT_SOURCE_PATH_LABEL);
         return value != null ? value.toString() : null;
+    }
+
+    /**
+     * @param column value
+     *        the new right criteria column (can be empty)
+     */
+    public void setRightCriteriaColumn(final String column) {
+        tuples.put(RestViewEditorState.RIGHT_CRITERIA_COLUMN_LABEL, column);
     }
 
     /**
@@ -201,6 +249,14 @@ public class RestSqlComposition extends RestBasicEntity {
     }
     
     /**
+     * @param column value
+     *        the new left criteria column (can be empty)
+     */
+    public void setLeftCriteriaColumn(final String column) {
+        tuples.put(RestViewEditorState.LEFT_CRITERIA_COLUMN_LABEL, column);
+    }
+
+    /**
      * @return the left node path (can be empty)
      */
     public String getLeftCriteriaColumn() {
@@ -209,11 +265,27 @@ public class RestSqlComposition extends RestBasicEntity {
     }
 
     /**
+     * @param type value
+     *        the new type (can be empty)
+     */
+    public void setType(final String type) {
+        tuples.put(RestViewEditorState.TYPE_LABEL, type);
+    }
+
+    /**
      * @return the composition type (can be empty)
      */
     public String getType() {
         Object value = tuples.get(RestViewEditorState.TYPE_LABEL);
         return value != null ? value.toString() : null;
+    }
+
+    /**
+     * @param operator value
+     *        the new operator (can be empty)
+     */
+    public void setOperator(final String operator) {
+        tuples.put(RestViewEditorState.OPERATOR_LABEL, operator);
     }
 
     /**

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestViewDefinition.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestViewDefinition.java
@@ -141,8 +141,8 @@ public class RestViewDefinition extends RestBasicEntity {
      * @return the view definition isComplete value (can be empty)
      */
     public boolean isComplete() {
-        Object result = tuples.get(RestViewEditorState.IS_COMPLETE);
-        return result != null ? Boolean.parseBoolean(result.toString()) : null;
+        Object hasIsComplete = tuples.get(RestViewEditorState.IS_COMPLETE);
+        return hasIsComplete != null ? Boolean.parseBoolean(hasIsComplete.toString()) : false;
     }
 
     /**
@@ -150,7 +150,7 @@ public class RestViewDefinition extends RestBasicEntity {
      *        the new description (can be empty)
      */
     public void setComplete(final boolean complete) {
-        tuples.put(RestViewEditorState.IS_COMPLETE, Boolean.toString(complete));
+        tuples.put(RestViewEditorState.IS_COMPLETE, complete);
     }
     
     /**
@@ -158,10 +158,13 @@ public class RestViewDefinition extends RestBasicEntity {
      */
     public String[] getSourcePaths() {
     	Object[] pathsRaw = (Object[])tuples.get(RestViewEditorState.SOURCE_PATHS);
-    	String[] pathsString = new String[pathsRaw.length];
-    	int i = 0;
-    	for( Object obj : pathsRaw ) {
-    		pathsString[i++] = (String)obj;
+    	int pathsLength = (pathsRaw != null) ? pathsRaw.length : 0;
+    	String[] pathsString = new String[pathsLength];
+    	if (pathsLength > 0) {
+        	int i = 0;
+        	for( Object obj : pathsRaw ) {
+        		pathsString[i++] = (String)obj;
+        	}
     	}
         return pathsString;
     }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestViewEditorState.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestViewEditorState.java
@@ -133,7 +133,7 @@ public class RestViewEditorState extends AbstractKEntity {
         
         ViewDefinition viewDef = viewEditorState.getViewDefinition(transaction);
         if( viewDef != null ) {
-        	viewDefinition = new RestViewDefinition(baseUri, viewDef, transaction);
+        	this.viewDefinition = new RestViewDefinition(baseUri, viewDef, transaction);
         }
 
         List<RestStateCommandAggregate> cmdList = new ArrayList<>();

--- a/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -324,7 +324,10 @@ Error.PROFILE_GIT_REPO_CREATE_MALFORMED_URL=The git repository url is not valid
 Error.PROFILE_GIT_REPO_CREATE_ERROR=An error occurred while creating a git repository configuration: %s
 Error.PROFILE_GIT_REPO_REMOVE_ERROR=An error occurred while removing a git repository configuration: %s
 Error.PROFILE_EDITOR_STATE_MISSING_ID=The view editor state id parameter is missing
-Error.PROFILE_EDITOR_STATE_MISSING_CONTENT=The view editor state content parameter is missing
+Error.PROFILE_EDITOR_STATE_MISSING_COMMANDS=The view editor state commands are missing
+Error.PROFILE_EDITOR_STATE_MISSING_VIEW_DEFINITION=The view editor state viewDefinition is missing
+Error.PROFILE_EDITOR_STATE_GET_ERROR = An error occurred while getting a view editor state: %s
+Error.PROFILE_EDITOR_STATES_GET_ERROR = An error occurred while getting view editor states
 Error.PROFILE_EDITOR_STATE_CREATE_ERROR = An error occurred while storing a view editor state: %s
 Error.PROFILE_EDITOR_STATE_REMOVE_ERROR = An error occurred while removing a view editor state: %s
 

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/RestDataserviceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/RestDataserviceTest.java
@@ -75,8 +75,7 @@ public final class RestDataserviceTest {
         copy.setServiceVdbName(this.dataservice.getServiceVdbName());
         copy.setServiceVdbVersion(this.dataservice.getServiceVdbVersion());
         copy.setServiceViewModel(this.dataservice.getServiceViewModel());
-        copy.setServiceViewNames(this.dataservice.getServiceViewNames());
-        copy.setServiceViewTables(this.dataservice.getServiceViewTables());
+        copy.setViewDefinitionNames(this.dataservice.getViewDefinitionNames());
         copy.setDriverTotal(this.dataservice.getDriverTotal());
         copy.setConnectionTotal(this.dataservice.getConnectionTotal());
 
@@ -119,11 +118,7 @@ public final class RestDataserviceTest {
         String[] viewNames = new String[2];
         viewNames[0] = SERVICE_VIEW1;
         viewNames[1] = SERVICE_VIEW2;
-        this.dataservice.setServiceViewNames(viewNames);
-        String[] viewTables = new String[2];
-        viewTables[0] = SERVICE_VIEW_SRCTABLE1;
-        viewTables[1] = SERVICE_VIEW_SRCTABLE2;
-        this.dataservice.setServiceViewTables(viewTables);
+        this.dataservice.setViewDefinitionNames(viewNames);
     }
 
     @Test
@@ -207,8 +202,8 @@ public final class RestDataserviceTest {
     	final String[] views = new String[2];
     	views[0] = "blah1";
     	views[1] = "blah2";
-        this.dataservice.setServiceViewNames(views);
-        assertEquals(this.dataservice.getServiceViewNames(), views);
+        this.dataservice.setViewDefinitionNames(views);
+        assertEquals(this.dataservice.getViewDefinitionNames(), views);
     }
 
 

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/DataserviceSerializerTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/DataserviceSerializerTest.java
@@ -47,7 +47,6 @@ public final class DataserviceSerializerTest extends AbstractSerializerTest  {
         "  \"keng__hasChildren\": true," + NEW_LINE +
         "  \"tko__description\": \"my description\"," + NEW_LINE +
         "  \"serviceVdbVersion\": \"1\"," + NEW_LINE +
-        "  \"serviceViewTables\": []," + NEW_LINE +
         "  \"connections\": 0," + NEW_LINE +
         "  \"drivers\": 0," + NEW_LINE +
         "  \"keng___links\": [" + NEW_LINE +

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/ViewEditorStateSerializerTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/ViewEditorStateSerializerTest.java
@@ -82,7 +82,7 @@ public class ViewEditorStateSerializerTest extends AbstractSerializerTest {
                 	tab(2) + q(RestViewEditorState.BASE_URI) + colon() + q(MY_BASE_URI) + pnl(COMMA) +
                 	tab(2) + q(RestViewEditorState.ID_VIEW_NAME) + colon() + q(viewDefinitionName) + pnl(COMMA) +
                 	tab(2) + q(RestViewEditorState.DESCRIPTION) + colon() + q(description) + pnl(COMMA) +
-                	tab(2) + q(RestViewEditorState.IS_COMPLETE) + colon() + q(isComplete) + pnl(COMMA) +
+                	tab(2) + q(RestViewEditorState.IS_COMPLETE) + colon() + isComplete + pnl(COMMA) +
                 	tab(2) + q(RestViewEditorState.SOURCE_PATHS) + colon() + pnl(OPEN_SQUARE_BRACKET) +
                 		tab(3) + q(sourceTablePath1) + pnl(COMMA) +
                 		tab(3) + q(sourceTablePath2) + pnl(COMMA) +

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/unit/KomodoDataserviceServiceTestInSuite.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/unit/KomodoDataserviceServiceTestInSuite.java
@@ -51,6 +51,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.komodo.relational.ViewBuilderCriteriaPredicate;
+import org.komodo.relational.profile.ViewEditorState;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.rest.KomodoRestV1Application.V1Constants;
 import org.komodo.rest.RestLink;
@@ -1118,10 +1119,28 @@ public class KomodoDataserviceServiceTestInSuite extends AbstractKomodoServiceTe
         undoArgs.put( "newNameKey", oldName );
         undoArgs.put( "oldNameKey", newName );
 
+        // View Defn properties
+        final String viewDescr = "viewName description";
+        final String[] sourcePaths = new String[2];
+        sourcePaths[0] = "connection=conn1/schema=public/table=customer";
+        sourcePaths[1] = "connection=conn1/schema=public/table=account";
+        final String compName = "left-right";
+        final String compDescr = "composition description";
+        final String compLeftSource = "connection=conn1/schema=public/table=customer";
+        final String compRightSource = "connection=conn1/schema=public/table=account";
+        final String leftColumn = "leftCol";
+        final String rightColumn = "rightCol";
+        final String type = "INNER_JOIN";
+        final String operator = "EQ";
+        
         // setup test by creating view and view editor state
         final String modelName = "MyModel";
         this.serviceTestUtilities.createVdbModelView( vdbName, modelName, viewName, USER_NAME );
-        this.serviceTestUtilities.addViewEditorState( USER_NAME, editorStateId, undoId, undoArgs, redoId, redoArgs );
+        this.serviceTestUtilities.addViewEditorState( USER_NAME, editorStateId, 
+        		                                                 undoId, undoArgs, redoId, redoArgs,
+        		                                                 viewName, viewDescr, sourcePaths,
+        		                                                 compName, compDescr, compLeftSource, compRightSource,
+        		                                                 leftColumn, rightColumn, type, operator);
         assertThat( this.serviceTestUtilities.viewEditorStateExists( USER_NAME, editorStateId ), is( true ) );
 
         // delete virtualization and make sure editor state is deleted

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/unit/KomodoVdbServiceTestInSuite.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/unit/KomodoVdbServiceTestInSuite.java
@@ -371,9 +371,28 @@ public class KomodoVdbServiceTestInSuite extends AbstractKomodoServiceTest {
         undoArgs.put( "newNameKey", oldName );
         undoArgs.put( "oldNameKey", newName );
 
+        // View Defn properties
+        final String viewDescr = "viewName description";
+        final String[] sourcePaths = new String[2];
+        sourcePaths[0] = "connection=conn1/schema=public/table=customer";
+        sourcePaths[1] = "connection=conn1/schema=public/table=account";
+        final String compName = "left-right";
+        final String compDescr = "composition description";
+        final String compLeftSource = "connection=conn1/schema=public/table=customer";
+        final String compRightSource = "connection=conn1/schema=public/table=account";
+        final String leftColumn = "leftCol";
+        final String rightColumn = "rightCol";
+        final String type = "INNER_JOIN";
+        final String operator = "EQ";
+        
         // setup test by creating view and view editor state
         this.serviceTestUtilities.createVdbModelView( vdbName, modelName, viewName, USER_NAME );
-        this.serviceTestUtilities.addViewEditorState(USER_NAME, editorStateId, undoId, undoArgs, redoId, redoArgs );
+        this.serviceTestUtilities.addViewEditorState(USER_NAME, editorStateId, 
+        		                                                undoId, undoArgs, redoId, redoArgs,
+                                                                viewName, viewDescr, sourcePaths,
+                                                                compName, compDescr, compLeftSource, compRightSource,
+                                                                leftColumn, rightColumn, type, operator);
+
         assertThat( this.serviceTestUtilities.viewEditorStateExists( USER_NAME, editorStateId ), is( true ) );
 
         // now test by deleting the view


### PR DESCRIPTION
The rest returns for ViewEditorState now include the ViewDefinitions
- minor changes to the cnd
- eliminate grouping node for viewDefinition (there can only be one per editor state)
- change RestDataservice to return the corresponding editorState ViewDefinition names
- adds serializer for SqlComposition 
- modify unitTests to adapt to changes


