### PR TITLE
TTOOLS-477 Fix issue with UtilService

### DIFF
--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/ViewEditorStateSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/ViewEditorStateSerializer.java
@@ -41,7 +41,7 @@ public class ViewEditorStateSerializer extends AbstractEntitySerializer<RestView
 
     @Override
     protected boolean isComplete(RestViewEditorState entity) {
-        return entity.getId() != null && entity.getCommands() != null;
+        return entity.getId() != null;
     }
 
     @Override

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoUtilService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoUtilService.java
@@ -934,6 +934,7 @@ public final class KomodoUtilService extends KomodoService {
             for (String restSourcePath: restViewDefn.getSourcePaths()) {
                 viewDefn.addSourcePath(uow, restSourcePath);
             }
+            viewDefn.setComplete(uow, restViewDefn.isComplete());
             for (RestSqlComposition restComp: restViewDefn.getSqlCompositions()) {
             	SqlComposition sqlComp = viewDefn.addSqlComposition(uow, restComp.getId());
             	sqlComp.setDescription(uow, restComp.getDescription());

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/unit/KomodoUtilServiceTestInSuite.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/unit/KomodoUtilServiceTestInSuite.java
@@ -518,6 +518,7 @@ public class KomodoUtilServiceTestInSuite extends AbstractKomodoServiceTest {
         restViewDefn.setDescription(viewDescr);
         restViewDefn.setSourcePaths(sourcePaths);
         restViewDefn.setSqlCompositions(compositionArray);
+        restViewDefn.setComplete(true);
         
         restViewEditorState.setViewDefinition(restViewDefn);
         


### PR DESCRIPTION
- Minor change to KomodoUtilService.  Transfers the complete status for the ViewDefinition.  Also added to unit test.
- Change to ViewEditorStateSerializer isComplete.  The commands are not required for state to be complete.