### PR TITLE
TEIIDTOOLS-488 Add ability to bulk stash editorStates

### DIFF
--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
@@ -631,7 +631,12 @@ public class KomodoRestV1Application extends Application implements SystemConsta
         /**
          * The view editor state of the user profile
          */
-        String VIEW_EDITOR_STATE = "viewEditorState";
+        String VIEW_EDITOR_STATE = "viewEditorState"; //$NON-NLS-1$
+
+        /**
+         * The view editor state of the user profile
+         */
+        String VIEW_EDITOR_STATES = "viewEditorStates"; //$NON-NLS-1$
 
         /**
          * View editor state placeholder


### PR DESCRIPTION
- changed the stashViewEditorState method to stashViewEditorStates.  The method now takes an array of editor states, rather than a single state - this allows bulk creation of views.
- adapted the unit tests.