### PR TITLE
TTOOLS-465 Adds projected columns to view definition

### DIFF
--- a/komodo-core/src/main/java/org/komodo/core/KomodoLexicon.java
+++ b/komodo-core/src/main/java/org/komodo/core/KomodoLexicon.java
@@ -1025,10 +1025,15 @@ public interface KomodoLexicon extends StringConstants {
          * The name of the sql compositions child node. Value is {@value} .
          */
         String SQL_COMPOSITIONS = Namespace.PREFIX + COLON + "sqlCompositions"; //$NON-NLS-1$
+
+        /**
+         * The name of the sql projected columns child node. Value is {@value} .
+         */
+        String SQL_PROJECTED_COLUMNS = Namespace.PREFIX + COLON + "projectedColumns"; //$NON-NLS-1$
     }
     
     /**
-     * The JCR names associated with the view definition node type.
+     * The JCR names associated with the sql composition node type.
      */
     interface SqlComposition {
 
@@ -1071,6 +1076,32 @@ public interface KomodoLexicon extends StringConstants {
          * The name of the view definition operator property. Value is {@value} .
          */
         String OPERATOR = Namespace.PREFIX + COLON + "operator"; //$NON-NLS-1$
+    }
+
+    /**
+     * The JCR names associated with the sql projected column node type.
+     */
+    interface SqlProjectedColumn {
+
+        /**
+         * The name of the view definition node type. Value is {@value} .
+         */
+        String NODE_TYPE = Namespace.PREFIX + COLON + "projectedColumn"; //$NON-NLS-1$
+        
+        /**
+         * The name of the projected column name property. Value is {@value} .
+         */
+        String NAME = Namespace.PREFIX + COLON + "name"; //$NON-NLS-1$
+
+        /**
+         * The name of the projected column type property. Value is {@value} .
+         */
+        String TYPE = Namespace.PREFIX + COLON + "type"; //$NON-NLS-1$
+
+        /**
+         * The name of the projected column selected property. Value is {@value} .
+         */
+        String IS_SELECTED = Namespace.PREFIX + COLON + "selected"; //$NON-NLS-1$
     }
 
     /**

--- a/komodo-core/src/main/resources/config/komodo.cnd
+++ b/komodo-core/src/main/resources/config/komodo.cnd
@@ -243,6 +243,17 @@
   + * (tko:sqlComposition) copy
 
 /*
+ * a projected column
+ */
+[tko:projectedColumn] > nt:unstructured
+  - tko:name (string)
+  - tko:type (string)
+  - tko:selected (boolean) = 'true' mandatory autocreated
+
+[tko:projectedColumns] > nt:unstructured
+  + * (tko:projectedColumn) copy
+
+/*
  * the view definition containing properties and command for a view
  */
 [tko:viewDefinition] > nt:unstructured
@@ -251,6 +262,7 @@
   - tko:isComplete (boolean) = 'false' mandatory autocreated
   - tko:sourcePaths (string) multiple
   + tko:sqlCompositions (tko:sqlCompositions)
+  + tko:projectedColumns (tko:projectedColumns)
 
 /*
  * The state of a view editor when saved

--- a/komodo-relational/src/main/java/org/komodo/relational/Messages.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/Messages.java
@@ -317,9 +317,14 @@ public class Messages implements StringConstants {
          * An error indicating a sql composition object could not be found
          * while trying to remove it
          */
-    	SQL_COMPOSITION_NOT_FOUND_TO_REMOVE,
-    	
-    	
+        SQL_COMPOSITION_NOT_FOUND_TO_REMOVE,
+        
+        /**
+         * An error indicating a projected column object could not be found
+         * while trying to remove it
+         */
+        PROJECTED_COLUMN_NOT_FOUND_TO_REMOVE,
+        
         /**
          * An error indicating a source path already exists in the list
          * while trying to add it

--- a/komodo-relational/src/main/java/org/komodo/relational/RelationalModelFactory.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/RelationalModelFactory.java
@@ -90,15 +90,17 @@ import org.komodo.relational.model.internal.VirtualProcedureImpl;
 import org.komodo.relational.profile.GitRepository;
 import org.komodo.relational.profile.Profile;
 import org.komodo.relational.profile.SqlComposition;
+import org.komodo.relational.profile.SqlProjectedColumn;
 import org.komodo.relational.profile.StateCommand;
-import org.komodo.relational.profile.ViewEditorState;
 import org.komodo.relational.profile.StateCommandAggregate;
 import org.komodo.relational.profile.ViewDefinition;
+import org.komodo.relational.profile.ViewEditorState;
 import org.komodo.relational.profile.internal.GitRepositoryImpl;
 import org.komodo.relational.profile.internal.SqlCompositionImpl;
+import org.komodo.relational.profile.internal.SqlProjectedColumnImpl;
 import org.komodo.relational.profile.internal.StateCommandAggregateImpl;
-import org.komodo.relational.profile.internal.ViewEditorStateImpl;
 import org.komodo.relational.profile.internal.ViewDefinitionImpl;
+import org.komodo.relational.profile.internal.ViewEditorStateImpl;
 import org.komodo.relational.resource.DdlFile;
 import org.komodo.relational.resource.Driver;
 import org.komodo.relational.resource.ResourceFile;
@@ -1770,20 +1772,10 @@ public final class RelationalModelFactory {
    *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
    * @param repository
    *        the repository where the model object will be created (cannot be <code>null</code>)
-   * @param viewDefinitionImpl
-   *        the parent profile object
+   * @param viewDefinition
+   *        the parent view definition
    * @param compositionName
    *        the sql composition name
-   * @param description
-   *        the description
-   * @param leftSourcePath
-   *        the path to the left source table
-   * @param rightSourcePath
-   *        the path to the right source table
-   * @param type
-   *        the composition type
-   * @param operator
-   *        the operator for the criteria
    * @return the sql composition object
    * @throws KException
    *        if an error occurs
@@ -1809,6 +1801,41 @@ public final class RelationalModelFactory {
 	       }
 	}
 
+	/**
+	 *
+	 * @param transaction
+	 *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+	 * @param repository
+	 *        the repository where the model object will be created (cannot be <code>null</code>)
+	 * @param viewDefinition
+	 *        the parent view definition
+	 * @param columnName
+	 *        the sql projected column name
+	 * @return the sql projected column object
+	 * @throws KException
+	 *        if an error occurs
+	 */
+	public static SqlProjectedColumn createSqlProjectedColumn(UnitOfWork transaction, 
+	                                                          Repository repository, 
+	                                                          ViewDefinition viewDefinition, 
+	                                                          String columnName) throws KException {
+
+	    ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+	    ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+	    ArgCheck.isNotNull( repository, "repository" ); //$NON-NLS-1$
+	    ArgCheck.isNotNull( columnName, "columnName" ); //$NON-NLS-1$
+
+	    try {
+	        final KomodoObject grouping = RepositoryTools.findOrCreateChild( transaction, viewDefinition, KomodoLexicon.ViewDefinition.SQL_PROJECTED_COLUMNS,
+	                                                                         KomodoLexicon.ViewDefinition.SQL_PROJECTED_COLUMNS );
+	        final KomodoObject kobject = grouping.addChild( transaction, columnName, KomodoLexicon.SqlProjectedColumn.NODE_TYPE );
+	        final SqlProjectedColumn result = new SqlProjectedColumnImpl( transaction, repository, kobject.getAbsolutePath() );
+	        return result;
+	    } catch ( final Exception e ) {
+	        throw handleError( e );
+	    }
+	}
+
     /**
      *
      * @param transaction
@@ -1821,9 +1848,8 @@ public final class RelationalModelFactory {
      * @throws KException
      *        if an error occurs
      */
-    public static StateCommandAggregate createStateCommandAggregate (
-                                                                                                          UnitOfWork transaction, Repository repository,
-                                                                                                          ViewEditorState viewEditorState) throws KException {
+    public static StateCommandAggregate createStateCommandAggregate (UnitOfWork transaction, Repository repository,
+                                                                     ViewEditorState viewEditorState) throws KException {
         ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
         ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
         ArgCheck.isNotNull( repository, "repository" ); //$NON-NLS-1$
@@ -1860,10 +1886,10 @@ public final class RelationalModelFactory {
     *        if an error occurs
     */
    public static StateCommand createStateCommand(UnitOfWork transaction, Repository repository,
-                                                                                                 StateCommandAggregate stateCommandAgg,
-                                                                                                 String stateCommandType,
-                                                                                                 String commandId,
-                                                                                                 Map<String, String> arguments) throws KException {
+                                                 StateCommandAggregate stateCommandAgg,
+                                                 String stateCommandType,
+                                                 String commandId,
+                                                 Map<String, String> arguments) throws KException {
        ArgCheck.isNotNull(transaction, "transaction"); //$NON-NLS-1$
        ArgCheck.isTrue((transaction.getState() == State.NOT_STARTED), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
        ArgCheck.isNotNull(repository, "repository"); //$NON-NLS-1$

--- a/komodo-relational/src/main/java/org/komodo/relational/profile/SqlComposition.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/profile/SqlComposition.java
@@ -33,6 +33,9 @@ import org.komodo.spi.repository.KomodoType;
 import org.komodo.spi.repository.Repository.UnitOfWork;
 import org.komodo.spi.repository.Repository.UnitOfWork.State;
 
+/**
+ * Interface for SqlComposition
+ */
 public interface SqlComposition  extends RelationalObject, StringConstants {
 
     /**

--- a/komodo-relational/src/main/java/org/komodo/relational/profile/SqlProjectedColumn.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/profile/SqlProjectedColumn.java
@@ -1,0 +1,167 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.relational.profile;
+
+import org.komodo.core.KomodoLexicon;
+import org.komodo.core.repository.ObjectImpl;
+import org.komodo.relational.RelationalObject;
+import org.komodo.relational.TypeResolver;
+import org.komodo.relational.profile.internal.SqlProjectedColumnImpl;
+import org.komodo.spi.KException;
+import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.spi.repository.Repository.UnitOfWork.State;
+
+/**
+ * Interface for SqlProjectedColumn
+ */
+public interface SqlProjectedColumn  extends RelationalObject, StringConstants {
+
+    /**
+     * The type identifier.
+     */
+    int TYPE_ID = SqlProjectedColumn.class.hashCode();
+
+    /**
+     * Identifier of this object
+     */
+    KomodoType IDENTIFIER = KomodoType.SQL_PROJECTED_COLUMN;
+    
+    /**
+     * An empty array of sql compositions.
+     */
+    SqlProjectedColumn[] NO_SQL_PROJECTED_COLUMNS = new SqlProjectedColumn[0];
+
+
+    /**
+     * The resolver of a {@link ViewDefinition}.
+     */
+    TypeResolver<SqlProjectedColumn> RESOLVER = new TypeResolver<SqlProjectedColumn>() {
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.TypeResolver#identifier()
+         */
+        @Override
+        public KomodoType identifier() {
+            return IDENTIFIER;
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.TypeResolver#owningClass()
+         */
+        @Override
+        public Class<SqlProjectedColumnImpl> owningClass() {
+            return SqlProjectedColumnImpl.class;
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.KomodoObject)
+         */
+        @Override
+        public boolean resolvable(final UnitOfWork transaction, final KomodoObject kobject) throws KException {
+            return ObjectImpl.validateType(transaction, kobject.getRepository(), kobject, KomodoLexicon.SqlComposition.NODE_TYPE);
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.KomodoObject)
+         */
+        @Override
+        public SqlProjectedColumn resolve(final UnitOfWork transaction, final KomodoObject kobject) throws KException {
+            if (kobject.getTypeId() == SqlProjectedColumn.TYPE_ID) {
+                return (SqlProjectedColumn)kobject;
+            }
+
+            return new SqlProjectedColumnImpl(transaction, kobject.getRepository(), kobject.getAbsolutePath());
+        }
+
+    };
+    
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param name
+     *        the new value for the <code>name</code> property
+     * @throws KException
+     *         if an error occurs
+     */
+    void setName(UnitOfWork transaction, String name) throws KException;
+    
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @return the value of the <code>name</code> property
+     * @throws KException
+     *         if an error occurs
+     */
+    @Override
+    String getName(UnitOfWork transaction) throws KException;
+    
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param type
+     *        the new value for the <code>type</code> property
+     * @throws KException
+     *         if an error occurs
+     */
+    void setType(UnitOfWork transaction, String type) throws KException;
+    
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @return the value of the <code>type</code> property
+     * @throws KException
+     *         if an error occurs
+     */
+    String getType(UnitOfWork transaction) throws KException;
+    
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param selected value for selected
+     * @throws KException
+     *         if an error occurs         
+     */
+    void setSelected(final UnitOfWork transaction, boolean selected) throws KException;
+    
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @return boolean value of selected
+     * @throws KException
+     *         if an error occurs         
+     */
+    boolean isSelected(final UnitOfWork transaction) throws KException;
+    
+}

--- a/komodo-relational/src/main/java/org/komodo/relational/profile/ViewDefinition.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/profile/ViewDefinition.java
@@ -148,7 +148,7 @@ public interface ViewDefinition  extends RelationalObject, StringConstants {
     /**
      * @param transaction
      *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
-     * @return the view name
+     * @param name the view name
      * @throws KException
      *         if an error occurs
      */
@@ -166,7 +166,7 @@ public interface ViewDefinition  extends RelationalObject, StringConstants {
     /**
      * @param transaction
      *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
-     * @param string value of description
+     * @param description value of description
      * @throws KException
      *         if an error occurs         
      */
@@ -175,7 +175,7 @@ public interface ViewDefinition  extends RelationalObject, StringConstants {
     /**
      * @param transaction
      *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
-     * @param boolean value for isComplete
+     * @param complete value for isComplete
      * @throws KException
      *         if an error occurs         
      */
@@ -204,21 +204,57 @@ public interface ViewDefinition  extends RelationalObject, StringConstants {
     /**
      * @param transaction
      *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
-     * @param sqlCompositionToRemove
-     *        the name of the sql composition being removed (cannot be empty)       
+     * @param sourcePathToRemove
+     *        the source path being removed (cannot be empty)       
+     * @return the source paths
      * @throws KException
      *         if an error occurs
      */
-    String[]  removeSourcePath( final UnitOfWork transaction,
-                         final String sourcePathToRemove ) throws KException;
+    String[] removeSourcePath( final UnitOfWork transaction,
+                                final String sourcePathToRemove ) throws KException;
     
     /**
      * @param transaction
      *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
-     * @param sourceTablePath
+     * @param sourcePath 
      *        the name of the source path (cannot be empty)
+     * @return the source paths
      * @throws KException
      *         if an error occurs
      */
     String[] addSourcePath( final UnitOfWork transaction, String sourcePath ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param columnName
+     *        the name of the projected column being added (cannot be empty)
+     * @return the new projected column (never <code>null</code>)
+     * @throws KException
+     *         if an error occurs
+     */
+    SqlProjectedColumn addProjectedColumn( final UnitOfWork transaction, String columnName ) throws KException;
+    
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param projectedColumnToRemove
+     *        the name of the projected column being removed (cannot be empty)       
+     * @throws KException
+     *         if an error occurs
+     */
+    void removeProjectedColumn( final UnitOfWork transaction,
+                                final String projectedColumnToRemove ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param namePatterns
+     *        optional name patterns (can be <code>null</code> or empty but cannot have <code>null</code> or empty elements)
+     * @return the sql projected columns (never <code>null</code> but can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    SqlProjectedColumn[] getProjectedColumns( final UnitOfWork transaction, final String... namePatterns ) throws KException;
+
 }

--- a/komodo-relational/src/main/java/org/komodo/relational/profile/internal/SqlProjectedColumnImpl.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/profile/internal/SqlProjectedColumnImpl.java
@@ -1,0 +1,142 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.relational.profile.internal;
+
+import org.komodo.core.KomodoLexicon;
+import org.komodo.relational.internal.RelationalObjectImpl;
+import org.komodo.relational.profile.SqlProjectedColumn;
+import org.komodo.relational.profile.ViewDefinition;
+import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
+import org.komodo.spi.repository.PropertyValueType;
+import org.komodo.spi.repository.Repository;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.spi.repository.Repository.UnitOfWork.State;
+import org.komodo.utils.ArgCheck;
+
+/**
+ * An implementation of a SQL projected column
+ */
+public class SqlProjectedColumnImpl  extends RelationalObjectImpl implements SqlProjectedColumn {
+    /**
+     * The allowed child types.
+     */
+    private static final KomodoType[] CHILD_TYPES = new KomodoType[] { SqlProjectedColumn.IDENTIFIER };
+
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param repository
+     *        the repository where the relational object exists (cannot be <code>null</code>)
+     * @param path
+     *        the path (cannot be empty)
+     * @throws KException
+     *         if an error occurs or if node at specified path is not a model
+     */
+	public SqlProjectedColumnImpl(UnitOfWork uow, Repository repository, String path) throws KException {
+		super(uow, repository, path);
+	}
+
+    @Override
+    public KomodoType getTypeIdentifier(UnitOfWork uow) {
+        return SqlProjectedColumn.IDENTIFIER;
+    }
+    
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.internal.RelationalObjectImpl#getParent(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public ViewDefinition getParent(final UnitOfWork transaction) throws KException {
+        ArgCheck.isNotNull(transaction, "transaction"); //$NON-NLS-1$
+        ArgCheck.isTrue((transaction.getState() == State.NOT_STARTED), "transaction state must be NOT_STARTED"); //$NON-NLS-1$
+
+        final KomodoObject grouping = super.getParent(transaction);
+        final ViewDefinition result = ViewDefinition.RESOLVER.resolve(transaction, grouping.getParent(transaction));
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.KomodoObject#getTypeId()
+     */
+    @Override
+    public int getTypeId() {
+        return TYPE_ID;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.core.repository.ObjectImpl#getChildTypes()
+     */
+    @Override
+    public KomodoType[] getChildTypes() {
+        return CHILD_TYPES;
+    }
+
+	@Override
+	public void setName(UnitOfWork transaction, String name) throws KException {
+		setObjectProperty(transaction, "setName", KomodoLexicon.SqlProjectedColumn.NAME, name); //$NON-NLS-1$
+	}
+
+	@Override
+	public String getName(UnitOfWork transaction) throws KException {
+        String value = getObjectProperty(transaction, PropertyValueType.STRING, 
+        		                                      "getName", //$NON-NLS-1$
+                                                      KomodoLexicon.SqlProjectedColumn.NAME );
+		return value;
+	}
+
+	@Override
+	public void setType(UnitOfWork transaction, String type) throws KException {
+		setObjectProperty(transaction, "setType", KomodoLexicon.SqlProjectedColumn.TYPE, type); //$NON-NLS-1$
+	}
+
+	@Override
+	public String getType(UnitOfWork transaction) throws KException {
+        String value = getObjectProperty(transaction, PropertyValueType.STRING, 
+        		                                      "getType", //$NON-NLS-1$
+                                                      KomodoLexicon.SqlProjectedColumn.TYPE );
+		return value;
+	}
+	
+    @Override
+    public void setSelected(UnitOfWork transaction, boolean complete) throws KException {
+        setObjectProperty( transaction, "setComplete", KomodoLexicon.SqlProjectedColumn.IS_SELECTED, complete ); //$NON-NLS-1$
+    }
+
+    @Override
+    public boolean isSelected(UnitOfWork transaction) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+        
+        final Boolean value = getObjectProperty(transaction, PropertyValueType.BOOLEAN, 
+                                                             "isSelected", //$NON-NLS-1$
+                                                             KomodoLexicon.SqlProjectedColumn.IS_SELECTED );
+        return value;
+    }
+
+}

--- a/komodo-relational/src/main/resources/org/komodo/relational/messages.properties
+++ b/komodo-relational/src/main/resources/org/komodo/relational/messages.properties
@@ -58,6 +58,7 @@ Relational.RENAME_NOT_ALLOWED = The object at "{0}" cannot be renamed.
 Relational.RESULT_SET_NOT_FOUND_TO_REMOVE = A result set of procedure or function "{0}" could not be removed because it was not found
 Relational.SOURCE_PATH_NOT_FOUND_TO_REMOVE = Source path "{0}" could not be removed because it was not found
 Relational.SQL_COMPOSITION_NOT_FOUND_TO_REMOVE = Sql composition with id "{0}" could not be found
+Relational.PROJECTED_COLUMN_NOT_FOUND_TO_REMOVE = Projected column with id "{0}" could not be found
 Relational.STATEMENT_OPTION_NOT_FOUND_TO_REMOVE = StatementOption with name of "{0}" could not be removed because it was not found
 Relational.TABLE_NOT_FOUND_TO_REMOVE = Table with name of "{0}" could not be removed because it was not found
 Relational.TABLE_REF_NOT_SET = Columns to foreign key "{0}"''s table reference cannot be set until a table reference is set. 

--- a/komodo-spi/src/main/java/org/komodo/spi/repository/KomodoType.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/repository/KomodoType.java
@@ -189,6 +189,11 @@ public enum KomodoType {
     SQL_COMPOSITIONS,
     
     /**
+     * Sql ProjectedColumn
+     */
+    SQL_PROJECTED_COLUMN,
+
+    /**
      * View Editor State Command Aggregate
      */
     STATE_COMMAND_AGGREGATE,

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/KomodoJsonMarshaller.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/KomodoJsonMarshaller.java
@@ -84,11 +84,12 @@ import org.komodo.rest.relational.response.metadata.RestMetadataVdb;
 import org.komodo.rest.relational.response.metadata.RestMetadataVdbStatus;
 import org.komodo.rest.relational.response.metadata.RestMetadataVdbStatusVdb;
 import org.komodo.rest.relational.response.metadata.RestMetadataVdbTranslator;
-import org.komodo.rest.relational.response.vieweditorstate.RestViewEditorState;
 import org.komodo.rest.relational.response.vieweditorstate.RestSqlComposition;
+import org.komodo.rest.relational.response.vieweditorstate.RestSqlProjectedColumn;
 import org.komodo.rest.relational.response.vieweditorstate.RestStateCommandAggregate;
 import org.komodo.rest.relational.response.vieweditorstate.RestStateCommandAggregate.RestStateCommand;
 import org.komodo.rest.relational.response.vieweditorstate.RestViewDefinition;
+import org.komodo.rest.relational.response.vieweditorstate.RestViewEditorState;
 import org.komodo.rest.relational.response.virtualization.RestRouteStatus;
 import org.komodo.rest.relational.response.virtualization.RestVirtualizationStatus;
 import org.komodo.rest.schema.json.TeiidXsdReader;
@@ -170,6 +171,7 @@ public final class KomodoJsonMarshaller {
                                                   .registerTypeAdapter(RestViewEditorState.class, new ViewEditorStateSerializer())
                                                   .registerTypeAdapter(RestViewDefinition.class, new ViewDefinitionSerializer())
                                                   .registerTypeAdapter(RestSqlComposition.class, new SqlCompositionSerializer())
+                                                  .registerTypeAdapter(RestSqlProjectedColumn.class, new SqlProjectedColumnSerializer())
                                                   .registerTypeAdapter(RestStateCommandAggregate.class, new ViewEditorStateCommandSerializer())
                                                   .registerTypeAdapter(RestStateCommand.class, new ViewEditorStateCmdUnitSerializer())
                                                   .registerTypeAdapter(RestVirtualizationStatus.class, new VirtualizationStatusSerializer())

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/SqlCompositionSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/SqlCompositionSerializer.java
@@ -35,6 +35,9 @@ import com.google.gson.stream.JsonWriter;
 
 
 
+/**
+ * Serializer for Sql Composition
+ */
 public class SqlCompositionSerializer extends TypeAdapter<RestSqlComposition> {
 
 	@Override

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/SqlProjectedColumnSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/SqlProjectedColumnSerializer.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational.json;
+
+import static org.komodo.rest.Messages.Error.UNEXPECTED_JSON_TOKEN;
+import java.io.IOException;
+import org.komodo.rest.Messages;
+import org.komodo.rest.relational.response.vieweditorstate.RestSqlProjectedColumn;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * Serializer for projected columns
+ */
+public class SqlProjectedColumnSerializer extends TypeAdapter<RestSqlProjectedColumn> {
+
+	@Override
+	public void write(JsonWriter out, RestSqlProjectedColumn restSqlProjectedColumn) throws IOException {
+		out.beginObject();
+		
+        out.name(RestSqlProjectedColumn.NAME_LABEL);
+        out.value(restSqlProjectedColumn.getName());
+
+        out.name(RestSqlProjectedColumn.TYPE_LABEL);
+        out.value(restSqlProjectedColumn.getType());
+        
+        out.name(RestSqlProjectedColumn.SELECTED_LABEL);
+        out.value(restSqlProjectedColumn.isSelected());
+		
+        out.endObject();
+	}
+
+	@Override
+	public RestSqlProjectedColumn read(JsonReader in) throws IOException {
+	    RestSqlProjectedColumn sqlCol = new RestSqlProjectedColumn();
+		
+		in.beginObject();
+		
+
+        while ( in.hasNext() ) {
+            final String name = in.nextName();
+
+            switch ( name ) {
+                case RestSqlProjectedColumn.NAME_LABEL:
+                	sqlCol.setName(in.nextString());
+                    break;
+                case RestSqlProjectedColumn.TYPE_LABEL:
+                	sqlCol.setType(in.nextString());
+                    break;
+                case RestSqlProjectedColumn.SELECTED_LABEL:
+                	sqlCol.setSelected(in.nextBoolean());
+                    break;
+                default: {
+                    throw new IOException( Messages.getString( UNEXPECTED_JSON_TOKEN, name ));
+                }
+            }
+        }
+
+        in.endObject();
+		
+		return sqlCol;
+	}
+
+
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/ViewDefinitionSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/ViewDefinitionSerializer.java
@@ -23,14 +23,12 @@ package org.komodo.rest.relational.json;
 
 import static org.komodo.rest.Messages.Error.UNEXPECTED_JSON_TOKEN;
 import static org.komodo.rest.relational.json.KomodoJsonMarshaller.BUILDER;
-
 import java.io.IOException;
-
 import org.komodo.rest.Messages;
 import org.komodo.rest.relational.response.vieweditorstate.RestSqlComposition;
+import org.komodo.rest.relational.response.vieweditorstate.RestSqlProjectedColumn;
 import org.komodo.rest.relational.response.vieweditorstate.RestViewDefinition;
 import org.komodo.rest.relational.response.vieweditorstate.RestViewEditorState;
-
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
@@ -68,14 +66,24 @@ public class ViewDefinitionSerializer extends TypeAdapter<RestViewDefinition> {
 			out.endArray();
 		}
 		
-		RestSqlComposition[] comps = restViewDef.getSqlCompositions();
-		if( comps.length != 0 ) {
-        	out.name(RestViewEditorState.COMPOSITIONS_LABEL);
-        	out.beginArray();
-        	for( RestSqlComposition comp : comps) {
-        		BUILDER.getAdapter(RestSqlComposition.class).write(out, comp);
-        	}
-        	out.endArray();
+        RestSqlComposition[] comps = restViewDef.getSqlCompositions();
+        if( comps.length != 0 ) {
+            out.name(RestViewEditorState.COMPOSITIONS_LABEL);
+            out.beginArray();
+            for( RestSqlComposition comp : comps) {
+                BUILDER.getAdapter(RestSqlComposition.class).write(out, comp);
+            }
+            out.endArray();
+        }
+
+        RestSqlProjectedColumn[] cols = restViewDef.getProjectedColumns();
+        if( cols.length != 0 ) {
+            out.name(RestViewEditorState.PROJECTED_COLUMNS_LABEL);
+            out.beginArray();
+            for( RestSqlProjectedColumn col : cols) {
+                BUILDER.getAdapter(RestSqlProjectedColumn.class).write(out, col);
+            }
+            out.endArray();
         }
 		out.endObject();
 	}
@@ -107,6 +115,10 @@ public class ViewDefinitionSerializer extends TypeAdapter<RestViewDefinition> {
                 case RestViewEditorState.COMPOSITIONS_LABEL:
                     RestSqlComposition[] comps = BUILDER.fromJson(in, RestSqlComposition[].class);
                     viewDef.setSqlCompositions(comps);
+                    break;
+                case RestViewEditorState.PROJECTED_COLUMNS_LABEL:
+                    RestSqlProjectedColumn[] cols = BUILDER.fromJson(in, RestSqlProjectedColumn[].class);
+                    viewDef.setProjectedColumns(cols);
                     break;
                 case RestViewEditorState.BASE_URI:
                 	in.nextString();

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestSqlProjectedColumn.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestSqlProjectedColumn.java
@@ -1,0 +1,148 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational.response.vieweditorstate;
+
+import java.net.URI;
+import org.komodo.relational.profile.SqlProjectedColumn;
+import org.komodo.rest.RestBasicEntity;
+import org.komodo.spi.KException;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+
+/**
+ * Rest object for a projected column
+ */
+public class RestSqlProjectedColumn extends RestBasicEntity {
+	
+    /**
+     * Label used for column name
+     */
+    public static final String NAME_LABEL = "name"; //$NON-NLS-1$
+    
+    /**
+     * label used for column type
+     */
+    public static final String TYPE_LABEL = "type"; //$NON-NLS-1$
+
+    /**
+     * label used for column selected
+     */
+    public static final String SELECTED_LABEL = "selected"; //$NON-NLS-1$
+
+    /**
+     * Constructor for use <strong>only</strong> when deserializing.
+     */
+    public RestSqlProjectedColumn() {
+    	
+    }
+    
+    /**
+     * Constructor
+     * @param projCol the column
+     */
+    public RestSqlProjectedColumn(final RestSqlProjectedColumn projCol) {
+        this.setName(projCol.getName());
+        this.setType(projCol.getType());
+        this.setSelected(projCol.isSelected());
+    }
+    
+    /**
+     * Constructor
+     * @param baseUri base uri
+     * @param sqlProjectedColumn the projected column
+     * @param uow transaction
+     * @throws KException if error
+     */
+    public RestSqlProjectedColumn(URI baseUri, SqlProjectedColumn sqlProjectedColumn, UnitOfWork uow) throws KException {
+        super(baseUri);
+        
+        String value = sqlProjectedColumn.getName(uow);
+        this.setName(value);
+        
+        value = sqlProjectedColumn.getType(uow);
+        this.setType(value);
+        
+        boolean bVal = sqlProjectedColumn.isSelected(uow);
+        this.setSelected(bVal);
+    }
+
+    /**
+     * Constructor
+     * @param name the column name
+     * @param type the column type
+     * @param selected the column selection state
+     */
+    public RestSqlProjectedColumn(String name,
+    						      String type,
+      						      boolean selected) {
+        this.setName(name);
+        this.setType(type);
+        this.setSelected(selected);
+    }
+
+    /**
+     * @param name value
+     *        the new name (can be empty)
+     */
+    public void setName(final String name) {
+        tuples.put(NAME_LABEL, name);
+    }
+
+    /**
+     * @return the name (can be empty)
+     */
+    public String getName() {
+        Object value = tuples.get(NAME_LABEL);
+        return value != null ? value.toString() : null;
+    }
+    
+    /**
+     * @param type value
+     *        the new type (can be empty)
+     */
+    public void setType(final String type) {
+        tuples.put(TYPE_LABEL, type);
+    }
+
+    /**
+     * @return the column type (can be empty)
+     */
+    public String getType() {
+        Object value = tuples.get(TYPE_LABEL);
+        return value != null ? value.toString() : null;
+    }
+
+    /**
+     * @return selected flag
+     */
+    public boolean isSelected() {
+        Object value = tuples.get(SELECTED_LABEL);
+        return value != null ? Boolean.parseBoolean(value.toString()) : false;
+    }
+
+    /**
+     * @param selected 'true' if selected
+     */
+    public void setSelected(boolean selected) {
+        tuples.put(SELECTED_LABEL, selected);
+    }
+
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestViewDefinition.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestViewDefinition.java
@@ -24,19 +24,26 @@ package org.komodo.rest.relational.response.vieweditorstate;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.komodo.relational.profile.SqlComposition;
+import org.komodo.relational.profile.SqlProjectedColumn;
 import org.komodo.relational.profile.ViewDefinition;
 import org.komodo.rest.RestBasicEntity;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.Repository.UnitOfWork;
 
+/**
+ * Rest ViewDefinition
+ */
 public class RestViewDefinition extends RestBasicEntity {
 	
     /*
-     * The contents of the view editor state
+     * The view compositions
      */
     private RestSqlComposition[] compositions = new RestSqlComposition[0];
+    /*
+     * The view projected columns
+     */
+    private RestSqlProjectedColumn[] projectedColumns = new RestSqlProjectedColumn[0];
     
     /**
      * Constructor for use <strong>only</strong> when deserializing.
@@ -45,6 +52,11 @@ public class RestViewDefinition extends RestBasicEntity {
         // nothing to do
     }
     
+    /**
+     * Constructor
+     * @param viewDef the view definition
+     * @throws KException the exception
+     */
     public RestViewDefinition(final RestViewDefinition viewDef) throws KException {
     	super(viewDef.getBaseUri());
     	
@@ -69,6 +81,13 @@ public class RestViewDefinition extends RestBasicEntity {
         	compList.add(restComp);
         }
         this.compositions = compList.toArray(new RestSqlComposition[0]);
+        
+        List<RestSqlProjectedColumn> columnList = new ArrayList<>();
+        for (RestSqlProjectedColumn col : viewDef.getProjectedColumns()) {
+            RestSqlProjectedColumn restCol = new RestSqlProjectedColumn(col);
+            columnList.add(restCol);
+        }
+        this.projectedColumns = columnList.toArray(new RestSqlProjectedColumn[0]);
     }
 
     /**
@@ -103,6 +122,13 @@ public class RestViewDefinition extends RestBasicEntity {
         	compList.add(restComp);
         }
         this.compositions = compList.toArray(new RestSqlComposition[0]);
+        
+        List<RestSqlProjectedColumn> columnList = new ArrayList<>();
+        for (SqlProjectedColumn col : viewDef.getProjectedColumns(transaction)) {
+            RestSqlProjectedColumn restCol = new RestSqlProjectedColumn(baseUri, col, transaction);
+            columnList.add(restCol);
+        }
+        this.projectedColumns = columnList.toArray(new RestSqlProjectedColumn[0]);
     }
 
     /**
@@ -138,7 +164,7 @@ public class RestViewDefinition extends RestBasicEntity {
     }
     
     /**
-     * @return the view definition isComplete value (can be empty)
+     * @return the view definition isComplete status
      */
     public boolean isComplete() {
         Object hasIsComplete = tuples.get(RestViewEditorState.IS_COMPLETE);
@@ -146,8 +172,8 @@ public class RestViewDefinition extends RestBasicEntity {
     }
 
     /**
-     * @param isComplete value
-     *        the new description (can be empty)
+     * @param complete 
+     *        the complete status
      */
     public void setComplete(final boolean complete) {
         tuples.put(RestViewEditorState.IS_COMPLETE, complete);
@@ -185,10 +211,29 @@ public class RestViewDefinition extends RestBasicEntity {
      * @return the string array of sql compositions(can be empty)
      */
     public RestSqlComposition[] getSqlCompositions() {
-    	return compositions;
+        return compositions;
     }
     
+    /**
+     * Set the compositions
+     * @param compositions the compositions
+     */
     public void setSqlCompositions(RestSqlComposition[] compositions) {
         this.compositions = compositions;
+    }
+
+    /**
+     * @return the projected columns
+     */
+    public RestSqlProjectedColumn[] getProjectedColumns() {
+        return projectedColumns;
+    }
+    
+    /**
+     * Set the projected columns
+     * @param projCols the projected columns
+     */
+    public void setProjectedColumns(RestSqlProjectedColumn[] projCols) {
+        this.projectedColumns = projCols;
     }
 }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestViewEditorState.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestViewEditorState.java
@@ -98,6 +98,11 @@ public class RestViewEditorState extends AbstractKEntity {
     public static final String OPERATOR_LABEL = "operator";
     
     /**
+     * Label used for view definition projected columns array
+     */
+    public static final String PROJECTED_COLUMNS_LABEL = "projectedColumns";
+
+    /**
      * Label used for view editor start content
      */
     public static final String CONTENT_LABEL = "undoables";

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoUtilService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoUtilService.java
@@ -22,7 +22,6 @@
 package org.komodo.rest.service;
 
 import static org.komodo.rest.relational.RelationalMessages.Error.SCHEMA_SERVICE_GET_SCHEMA_ERROR;
-
 import java.io.File;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -30,7 +29,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -47,7 +45,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
-
 import org.komodo.core.KEngine;
 import org.komodo.core.repository.SynchronousCallback;
 import org.komodo.importer.ImportMessages;
@@ -58,6 +55,7 @@ import org.komodo.relational.importer.vdb.VdbImporter;
 import org.komodo.relational.profile.GitRepository;
 import org.komodo.relational.profile.Profile;
 import org.komodo.relational.profile.SqlComposition;
+import org.komodo.relational.profile.SqlProjectedColumn;
 import org.komodo.relational.profile.StateCommandAggregate;
 import org.komodo.relational.profile.ViewDefinition;
 import org.komodo.relational.profile.ViewEditorState;
@@ -72,6 +70,7 @@ import org.komodo.rest.relational.json.KomodoJsonMarshaller;
 import org.komodo.rest.relational.response.KomodoStatusObject;
 import org.komodo.rest.relational.response.RestGitRepository;
 import org.komodo.rest.relational.response.vieweditorstate.RestSqlComposition;
+import org.komodo.rest.relational.response.vieweditorstate.RestSqlProjectedColumn;
 import org.komodo.rest.relational.response.vieweditorstate.RestStateCommandAggregate;
 import org.komodo.rest.relational.response.vieweditorstate.RestStateCommandAggregate.RestStateCommand;
 import org.komodo.rest.relational.response.vieweditorstate.RestViewDefinition;
@@ -84,7 +83,6 @@ import org.komodo.spi.repository.Repository.Id;
 import org.komodo.spi.repository.Repository.UnitOfWork;
 import org.komodo.spi.repository.Repository.UnitOfWork.State;
 import org.komodo.utils.StringUtils;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
@@ -992,15 +990,23 @@ public final class KomodoUtilService extends KomodoService {
             viewDefn.addSourcePath(uow, restSourcePath);
         }
         viewDefn.setComplete(uow, restViewDefn.isComplete());
+        // Compositions
         for (RestSqlComposition restComp: restViewDefn.getSqlCompositions()) {
-        	SqlComposition sqlComp = viewDefn.addSqlComposition(uow, restComp.getId());
-        	sqlComp.setDescription(uow, restComp.getDescription());
-        	sqlComp.setLeftSourcePath(uow, restComp.getLeftSourcePath());
-        	sqlComp.setRightSourcePath(uow, restComp.getRightSourcePath());
-        	sqlComp.setLeftCriteriaColumn(uow, restComp.getLeftCriteriaColumn());
-        	sqlComp.setRightCriteriaColumn(uow, restComp.getRightCriteriaColumn());
-        	sqlComp.setType(uow, restComp.getType());
-        	sqlComp.setOperator(uow, restComp.getOperator());
+            SqlComposition sqlComp = viewDefn.addSqlComposition(uow, restComp.getId());
+            sqlComp.setDescription(uow, restComp.getDescription());
+            sqlComp.setLeftSourcePath(uow, restComp.getLeftSourcePath());
+            sqlComp.setRightSourcePath(uow, restComp.getRightSourcePath());
+            sqlComp.setLeftCriteriaColumn(uow, restComp.getLeftCriteriaColumn());
+            sqlComp.setRightCriteriaColumn(uow, restComp.getRightCriteriaColumn());
+            sqlComp.setType(uow, restComp.getType());
+            sqlComp.setOperator(uow, restComp.getOperator());
+        }
+        // Projected Columns
+        for (RestSqlProjectedColumn restCol: restViewDefn.getProjectedColumns()) {
+            SqlProjectedColumn sqlProjectedCol = viewDefn.addProjectedColumn(uow, restCol.getName());
+            sqlProjectedCol.setName(uow, restCol.getName());
+            sqlProjectedCol.setType(uow, restCol.getType());
+            sqlProjectedCol.setSelected(uow, restCol.isSelected());
         }
         return viewEditorState;
     }

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/ViewEditorStateSerializerTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/ViewEditorStateSerializerTest.java
@@ -30,15 +30,17 @@ import java.util.Map;
 import org.junit.Test;
 import org.komodo.core.KomodoLexicon;
 import org.komodo.relational.profile.SqlComposition;
+import org.komodo.relational.profile.SqlProjectedColumn;
 import org.komodo.relational.profile.StateCommand;
 import org.komodo.relational.profile.StateCommandAggregate;
 import org.komodo.relational.profile.ViewDefinition;
 import org.komodo.relational.profile.ViewEditorState;
 import org.komodo.rest.relational.response.vieweditorstate.RestSqlComposition;
+import org.komodo.rest.relational.response.vieweditorstate.RestSqlProjectedColumn;
 import org.komodo.rest.relational.response.vieweditorstate.RestStateCommandAggregate;
 import org.komodo.rest.relational.response.vieweditorstate.RestStateCommandAggregate.RestStateCommand;
-import org.komodo.rest.relational.response.vieweditorstate.RestViewEditorState;
 import org.komodo.rest.relational.response.vieweditorstate.RestViewDefinition;
+import org.komodo.rest.relational.response.vieweditorstate.RestViewEditorState;
 import org.komodo.spi.KException;
 
 public class ViewEditorStateSerializerTest extends AbstractSerializerTest {
@@ -71,6 +73,12 @@ public class ViewEditorStateSerializerTest extends AbstractSerializerTest {
     private String comp2RightColumn = "column4";
     private String comp2Type = "LEFT_OUTER_JOIN";
     private String comp2Operator = "EQ";
+    private String column1Name = "col1";
+    private String column1Type = "string";
+    private boolean column1Selected = false;
+    private String column2Name = "col2";
+    private String column2Type = "integer";
+    private boolean column2Selected = true;
  
     private String createViewEditorState() {
         String state = EMPTY_STRING +
@@ -90,29 +98,43 @@ public class ViewEditorStateSerializerTest extends AbstractSerializerTest {
                 		tab(3) + q(sourceTablePath4) + NEW_LINE +
                 		tab(2) + pnl(CLOSE_SQUARE_BRACKET + COMMA) +
                 
-                // compositions array
-                	tab(2) + q(RestViewEditorState.COMPOSITIONS_LABEL) + colon() + pnl(OPEN_SQUARE_BRACKET) + 
-                		tab(3) + OPEN_BRACE + NEW_LINE +
-                			tab(4) + q(RestViewEditorState.ID_NAME) + colon() + q(comp1Name) + pnl(COMMA) +
-                			tab(4) + q(RestViewEditorState.ID_DESCRIPTION) + colon() + q(comp1Desc) + pnl(COMMA) +
-                			tab(4) + q(RestViewEditorState.LEFT_SOURCE_PATH_LABEL) + colon() + q(comp1LeftSource) + pnl(COMMA) +
-                			tab(4) + q(RestViewEditorState.RIGHT_SOURCE_PATH_LABEL) + colon() + q(comp1RightSource) + pnl(COMMA) +
-                			tab(4) + q(RestViewEditorState.LEFT_CRITERIA_COLUMN_LABEL) + colon() + q(comp1LeftColumn) + pnl(COMMA) +
-                			tab(4) + q(RestViewEditorState.RIGHT_CRITERIA_COLUMN_LABEL) + colon() + q(comp1RightColumn) + pnl(COMMA) +
-                			tab(4) + q(RestViewEditorState.TYPE_LABEL) + colon() + q(comp1Type) + pnl(COMMA) +
-                			tab(4) + q(RestViewEditorState.OPERATOR_LABEL) + colon() + q(comp1Operator) +
-                		tab(3) + CLOSE_BRACE + pnl(COMMA) +
-                		tab(3) + OPEN_BRACE + NEW_LINE +
-            				tab(4) + q(RestViewEditorState.ID_NAME) + colon() + q(comp2Name) + pnl(COMMA) +
-            				tab(4) + q(RestViewEditorState.ID_DESCRIPTION) + colon() + q(comp2Desc) + pnl(COMMA) +
-            				tab(4) + q(RestViewEditorState.LEFT_SOURCE_PATH_LABEL) + colon() + q(comp2LeftSource) + pnl(COMMA) +
-            				tab(4) + q(RestViewEditorState.RIGHT_SOURCE_PATH_LABEL) + colon() + q(comp2RightSource) + pnl(COMMA) +
-                			tab(4) + q(RestViewEditorState.LEFT_CRITERIA_COLUMN_LABEL) + colon() + q(comp2LeftColumn) + pnl(COMMA) +
-                			tab(4) + q(RestViewEditorState.RIGHT_CRITERIA_COLUMN_LABEL) + colon() + q(comp2RightColumn) + pnl(COMMA) +
-            				tab(4) + q(RestViewEditorState.TYPE_LABEL) + colon() + q(comp2Type) + pnl(COMMA) +
-            				tab(4) + q(RestViewEditorState.OPERATOR_LABEL) + colon() + q(comp2Operator) + NEW_LINE +
-            			tab(3) + CLOSE_BRACE + NEW_LINE +
-            		tab(2) + pnl(CLOSE_SQUARE_BRACKET) +   
+                        // compositions array
+                        tab(2) + q(RestViewEditorState.COMPOSITIONS_LABEL) + colon() + pnl(OPEN_SQUARE_BRACKET) + 
+                            tab(3) + OPEN_BRACE + NEW_LINE +
+                                tab(4) + q(RestViewEditorState.ID_NAME) + colon() + q(comp1Name) + pnl(COMMA) +
+                                tab(4) + q(RestViewEditorState.ID_DESCRIPTION) + colon() + q(comp1Desc) + pnl(COMMA) +
+                                tab(4) + q(RestViewEditorState.LEFT_SOURCE_PATH_LABEL) + colon() + q(comp1LeftSource) + pnl(COMMA) +
+                                tab(4) + q(RestViewEditorState.RIGHT_SOURCE_PATH_LABEL) + colon() + q(comp1RightSource) + pnl(COMMA) +
+                                tab(4) + q(RestViewEditorState.LEFT_CRITERIA_COLUMN_LABEL) + colon() + q(comp1LeftColumn) + pnl(COMMA) +
+                                tab(4) + q(RestViewEditorState.RIGHT_CRITERIA_COLUMN_LABEL) + colon() + q(comp1RightColumn) + pnl(COMMA) +
+                                tab(4) + q(RestViewEditorState.TYPE_LABEL) + colon() + q(comp1Type) + pnl(COMMA) +
+                                tab(4) + q(RestViewEditorState.OPERATOR_LABEL) + colon() + q(comp1Operator) +
+                            tab(3) + CLOSE_BRACE + pnl(COMMA) +
+                            tab(3) + OPEN_BRACE + NEW_LINE +
+                                tab(4) + q(RestViewEditorState.ID_NAME) + colon() + q(comp2Name) + pnl(COMMA) +
+                                tab(4) + q(RestViewEditorState.ID_DESCRIPTION) + colon() + q(comp2Desc) + pnl(COMMA) +
+                                tab(4) + q(RestViewEditorState.LEFT_SOURCE_PATH_LABEL) + colon() + q(comp2LeftSource) + pnl(COMMA) +
+                                tab(4) + q(RestViewEditorState.RIGHT_SOURCE_PATH_LABEL) + colon() + q(comp2RightSource) + pnl(COMMA) +
+                                tab(4) + q(RestViewEditorState.LEFT_CRITERIA_COLUMN_LABEL) + colon() + q(comp2LeftColumn) + pnl(COMMA) +
+                                tab(4) + q(RestViewEditorState.RIGHT_CRITERIA_COLUMN_LABEL) + colon() + q(comp2RightColumn) + pnl(COMMA) +
+                                tab(4) + q(RestViewEditorState.TYPE_LABEL) + colon() + q(comp2Type) + pnl(COMMA) +
+                                tab(4) + q(RestViewEditorState.OPERATOR_LABEL) + colon() + q(comp2Operator) + NEW_LINE +
+                            tab(3) + CLOSE_BRACE + NEW_LINE +
+                        tab(2) + pnl(CLOSE_SQUARE_BRACKET + COMMA) +   
+
+                        // projected columns array
+                        tab(2) + q(RestViewEditorState.PROJECTED_COLUMNS_LABEL) + colon() + pnl(OPEN_SQUARE_BRACKET) + 
+                            tab(3) + OPEN_BRACE + NEW_LINE +
+                                tab(4) + q(RestSqlProjectedColumn.NAME_LABEL) + colon() + q(column1Name) + pnl(COMMA) +
+                                tab(4) + q(RestSqlProjectedColumn.TYPE_LABEL) + colon() + q(column1Type) + pnl(COMMA) +
+                                tab(4) + q(RestSqlProjectedColumn.SELECTED_LABEL) + colon() + column1Selected +
+                            tab(3) + CLOSE_BRACE + pnl(COMMA) +
+                            tab(3) + OPEN_BRACE + NEW_LINE +
+                                tab(4) + q(RestSqlProjectedColumn.NAME_LABEL) + colon() + q(column2Name) + pnl(COMMA) +
+                                tab(4) + q(RestSqlProjectedColumn.TYPE_LABEL) + colon() + q(column2Type) + pnl(COMMA) +
+                                tab(4) + q(RestSqlProjectedColumn.SELECTED_LABEL) + colon() + column2Selected + NEW_LINE +
+                            tab(3) + CLOSE_BRACE + NEW_LINE +
+                        tab(2) + pnl(CLOSE_SQUARE_BRACKET) +   
             	TAB + CLOSE_BRACE + pnl(COMMA) +
             	
                 // undoables child
@@ -233,6 +255,7 @@ public class ViewEditorStateSerializerTest extends AbstractSerializerTest {
         when(viewDef.isComplete(transaction)).thenReturn(isComplete);
         when(viewDef.getSourcePaths(transaction)).thenReturn(sourceTablePaths);
         
+        // Mocks for Compositions
         SqlComposition sqlComp1 = mock(SqlComposition.class);
         when(sqlComp1.getName(transaction)).thenReturn(comp1Name);
         when(sqlComp1.getDescription(transaction)).thenReturn(comp1Desc);
@@ -254,9 +277,22 @@ public class ViewEditorStateSerializerTest extends AbstractSerializerTest {
         when(sqlComp2.getOperator(transaction)).thenReturn(comp2Operator);
         
         SqlComposition[] sqlComps = { sqlComp1, sqlComp2 };
-        
         when(viewDef.getSqlCompositions(transaction)).thenReturn(sqlComps);
+
+        // Mocks for projected columns
+        SqlProjectedColumn sqlCol1 = mock(SqlProjectedColumn.class);
+        when(sqlCol1.getName(transaction)).thenReturn(column1Name);
+        when(sqlCol1.getType(transaction)).thenReturn(column1Type);
+        when(sqlCol1.isSelected(transaction)).thenReturn(column1Selected);
+
+        SqlProjectedColumn sqlCol2 = mock(SqlProjectedColumn.class);
+        when(sqlCol2.getName(transaction)).thenReturn(column2Name);
+        when(sqlCol2.getType(transaction)).thenReturn(column2Type);
+        when(sqlCol2.isSelected(transaction)).thenReturn(column2Selected);
         
+        SqlProjectedColumn[] sqlCols = { sqlCol1, sqlCol2 };
+        when(viewDef.getProjectedColumns(transaction)).thenReturn(sqlCols);
+
         when(state.getViewDefinition(transaction)).thenReturn(viewDef);
 
         RestViewEditorState restState = new RestViewEditorState(MY_BASE_URI, state, transaction);


### PR DESCRIPTION
Adds a projected column array to the view definition.  This is the initial implementation which allows user selection of individual columns for the view.  It will be refined in future as more capabilities are added and refined.
- adds projectedColumns to the cnd under view definition.
- adds the associated SqlProjectedColumn repo object.  Currently the column info includes name, type, and selection flag
- adds the necessary rest classes and modifies existing classes
- updates the unit tests
