### PR TITLE
TEIIDTOOLS-549 Updates rest method naming for syndesis

### DIFF
--- a/server/komodo-server/src/main/java/org/komodo/rest/KomodoRestV1Application.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/KomodoRestV1Application.java
@@ -595,9 +595,14 @@ public class KomodoRestV1Application extends Application implements SystemConsta
         String PING_TYPE_PARAMETER = "pingType"; //$NON-NLS-1$
         
         /**
-         * Available sources from OpenShift Service catalog
+         * syndesis source segment
          */
-        String SERVICE_CATALOG_SOURCES = "serviceCatalogSources"; //$NON-NLS-1$
+        String SYNDESIS_SOURCE = "syndesisSource"; //$NON-NLS-1$
+
+        /**
+         * syndesis sources segment
+         */
+        String SYNDESIS_SOURCES = "syndesisSources"; //$NON-NLS-1$
         
         /**
          * Bind to available source in OpenShift Service catalog

--- a/server/komodo-server/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -224,9 +224,9 @@ public final class RelationalMessages {
         CONNECTION_TO_REPO_SUCCESS,
         
         /**
-         * Bind operation with Service Catalog Data Source
+         * Bind operation with Syndesis Source
          */
-        METADATA_SERVICE_CATALOG_DATA_SERVIVE_BIND_TITLE;
+        METADATA_SYNDESIS_SOURCE_BIND_TITLE;
 
         /**
          * {@inheritDoc}
@@ -1451,24 +1451,24 @@ public final class RelationalMessages {
         IMPORT_EXPORT_SERVICE_NO_NAMED_GIT_REPO_ERROR,
 
         /**
-         * An error indicating the failed status of to get a data services from service catalog
+         * An error indicating the failed status of to get syndesis sources
          */
-        METADATA_GET_DATA_SOURCES_ERROR,
+        METADATA_GET_SYNDESIS_SOURCES_ERROR,
         
         /**
-         * An error indicating a name of data service missing from bind operation on service catalog service 
+         * An error indicating a name of syndesis source missing from bind operation 
          */
-        METADATA_DATA_SERVICE_BIND_MISSING_NAME,
+        METADATA_SYNDESIS_SOURCE_BIND_MISSING_NAME,
         
         /**
-         * An error indicating payload parse error from bind operation on service catalog service 
+         * An error indicating payload parse error from bind operation
          */
-        METADATA_DATA_SERVICE_BIND_PARSE_ERROR,
+        METADATA_SYNDESIS_SOURCE_BIND_PARSE_ERROR,
         
         /**
          * An error indicating from bind operation on service catalog service
          */
-        METADATA_DATA_SERVIVE_BIND_ERROR,
+        METADATA_SYNDESIS_SOURCE_BIND_ERROR,
 
         /**
          * An error indicating the about service failed

--- a/server/komodo-server/src/main/java/org/komodo/rest/relational/RestEntityFactory.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/relational/RestEntityFactory.java
@@ -237,7 +237,6 @@ public class RestEntityFactory implements V1Constants {
                                                                                                  TeiidDataSource teiidDataSource, URI baseUri)
                                                                                                    throws Exception {
         checkTransaction(transaction);
-        ArgCheck.isTrue(transaction.isRollbackOnly(), "transaction should be rollback-only");
 
         KomodoObject parent = createTemporaryParent(transaction, repository, null);
         Connection connection = RelationalModelFactory.createConnection(transaction, repository,parent.getAbsolutePath(), teiidDataSource.getName());

--- a/server/komodo-server/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-server/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -54,7 +54,7 @@ Info.CONNECTION_TO_REPO_STATUS_TITLE = Connection transfer to workspace Status
 Info.CONNECTION_TO_REPO_SUCCESS = Connection transfer to workspace was successful
 Info.CONNECTION_UNDEPLOYMENT_REQUEST_SENT = A request has been sent to delete the connection '%s'
 Info.CONNECTION_SUCCESSFULLY_UNDEPLOYED = The connection '%s' has been undeployed
-Info.METADATA_SERVICE_CATALOG_DATA_SERVIVE_BIND_TITLE=Bind Operation for Service Catalog Data Source %s
+Info.METADATA_SYNDESIS_SOURCE_BIND_TITLE=Bind Operation for Syndesis Source %s
 
 Error.ENCRYPT_FAILURE=An error occurred while attempting to encrypt sensitive data for the user %s
 Error.DECRYPT_FAILURE=An error occurred while attempting to decrypt sensitive data for the user %s
@@ -307,10 +307,10 @@ Error.IMPORT_EXPORT_SERVICE_MISSING_PARAMETER_ERROR = The parameter %s is requir
 Error.IMPORT_EXPORT_SERVICE_IMPORT_ARTIFACT_ERROR = An error occurred while attempting to perform the import: %s
 Error.IMPORT_EXPORT_SERVICE_NO_NAMED_GIT_REPO_ERROR = No git repository configuration named %s is defined in the user's profile
 
-Error.METADATA_GET_DATA_SOURCES_ERROR= An error occurred while attempting to read configured data sources: %s
-Error.METADATA_DATA_SERVICE_BIND_MISSING_NAME=The payload is missing name of the data source to bind to
-Error.METADATA_DATA_SERVICE_BIND_PARSE_ERROR=An error occurred while trying to parse payload for bind operation
-Error.METADATA_DATA_SERVIVE_BIND_ERROR=An error occurred during bind operation of source %s 
+Error.METADATA_GET_SYNDESIS_SOURCES_ERROR= An error occurred while attempting to read syndesis sources: %s
+Error.METADATA_SYNDESIS_SOURCE_BIND_MISSING_NAME=The payload is missing name of the syndesis source to bind to
+Error.METADATA_SYNDESIS_SOURCE_BIND_PARSE_ERROR=An error occurred while trying to parse payload for bind operation
+Error.METADATA_SYNDESIS_SOURCE_BIND_ERROR=An error occurred during bind operation of syndesis source %s 
 Error.ABOUT_SERVICE_ERROR=An error occurred while fetching information about the application: %s
 Error.USER_PROFILE_SERVICE_ERROR=An error occurred while fetching user profile information for the user: %s
 Error.NO_USER_PROFILE=The user profile for %s cannot be located

--- a/ui/beetle-lib/src/connections/add-connection-wizard/add-connection-wizard.component.ts
+++ b/ui/beetle-lib/src/connections/add-connection-wizard/add-connection-wizard.component.ts
@@ -447,7 +447,7 @@ export class AddConnectionWizardComponent implements OnInit {
 
     const self = this;
     this.connectionService
-      .getAllServiceCatalogSources()
+      .getAllSyndesisSources()
       .subscribe(
         (sources) => {
           // Only keep the service catalog sources whose type matches the connectionType.  empty source is always included.

--- a/ui/beetle-lib/src/connections/shared/connection.service.ts
+++ b/ui/beetle-lib/src/connections/shared/connection.service.ts
@@ -147,14 +147,14 @@ export class ConnectionService extends ApiService {
   }
 
   /**
-   * Bind a service catalog source via the komodo rest interface
-   * @param {string} serviceCatalogSourceName
+   * Bind a syndesis source via the komodo rest interface
+   * @param {string} syndesisSourceName
    * @returns {Observable<boolean>}
    */
-  public bindServiceCatalogSource(serviceCatalogSourceName: string): Observable<any> {
+  public bindSyndesisSource(syndesisSourceName: string): Observable<any> {
     return this.http
-      .post(environment.komodoTeiidUrl + ConnectionsConstants.serviceCatalogSourcesRootPath,
-        { name: serviceCatalogSourceName}, this.getAuthRequestOptions())
+      .post(environment.komodoTeiidUrl + ConnectionsConstants.syndesisSourcesRootPath,
+        { name: syndesisSourceName}, this.getAuthRequestOptions())
       .map((response) => {
         return response.ok;
       })
@@ -208,12 +208,12 @@ export class ConnectionService extends ApiService {
   }
 
   /**
-   * Get the available ServiceCatalogSources from the komodo rest interface
+   * Get the available SyndesisSources from the komodo rest interface
    * @returns {Observable<ServiceCatalogSource[]>}
    */
-  public getAllServiceCatalogSources(): Observable<ServiceCatalogSource[]> {
+  public getAllSyndesisSources(): Observable<ServiceCatalogSource[]> {
     return this.http
-      .get(environment.komodoTeiidUrl + ConnectionsConstants.serviceCatalogSourcesRootPath, this.getAuthRequestOptions())
+      .get(environment.komodoTeiidUrl + ConnectionsConstants.syndesisSourcesRootPath, this.getAuthRequestOptions())
       .map((response) => {
         const catalogSources = response.json();
         return catalogSources.map((catSource) => ServiceCatalogSource.create( catSource ));
@@ -265,7 +265,7 @@ export class ConnectionService extends ApiService {
   }
 
   /**
-   * Create a connection in the Komodo repo - also binds the specified serviceCatalogSource
+   * Create a connection in the Komodo repo - also binds the specified syndesisSource
    * @param {NewConnection} connection the connection object
    * @returns {Observable<boolean>}
    */
@@ -280,7 +280,7 @@ export class ConnectionService extends ApiService {
   }
 
   /**
-   * Update a connection in the Komodo repo - also binds the specified serviceCatalogSource.
+   * Update a connection in the Komodo repo - also binds the specified syndesisSource.
    * @param {NewConnection} connection the connection object
    * @returns {Observable<boolean>}
    */
@@ -295,7 +295,7 @@ export class ConnectionService extends ApiService {
   }
 
   /**
-   * Creates a workspace Connection, binds it to the specified serviceCatalogSource, and initiates
+   * Creates a workspace Connection, binds it to the specified syndesisSource, and initiates
    * a refresh of the connection schema.
    * @param {NewConnection} connection the connection object
    * @returns {Observable<boolean>}
@@ -307,7 +307,7 @@ export class ConnectionService extends ApiService {
   }
 
   /**
-   * Updates a workspace Connection, binds it to the specified serviceCatalogSource, and initiates
+   * Updates a workspace Connection, binds it to the specified syndesisSource, and initiates
    * a refresh of the connection schema.
    * @param {NewConnection} connection the connection object
    * @returns {Observable<boolean>}

--- a/ui/beetle-lib/src/connections/shared/connections-constants.ts
+++ b/ui/beetle-lib/src/connections/shared/connections-constants.ts
@@ -23,8 +23,8 @@ export class ConnectionsConstants {
   public static readonly addConnectionRoute = ConnectionsConstants.connectionsRootRoute + "/add-connection";
   public static readonly addConnectionPath = ConnectionsConstants.connectionsRootPath + "/add-connection";
 
-  public static readonly serviceCatalogSourcesRootRoute = "serviceCatalogSources";
-  public static readonly serviceCatalogSourcesRootPath = "/" + ConnectionsConstants.serviceCatalogSourcesRootRoute;
+  public static readonly syndesisSourcesRootRoute = "syndesisSources";
+  public static readonly syndesisSourcesRootPath = "/" + ConnectionsConstants.syndesisSourcesRootRoute;
 
   public static readonly connectionType_postgresql = "postgresql";
   public static readonly connectionType_mysql = "mysql";

--- a/ui/beetle-lib/src/connections/shared/mock-connection.service.ts
+++ b/ui/beetle-lib/src/connections/shared/mock-connection.service.ts
@@ -118,7 +118,7 @@ export class MockConnectionService extends ConnectionService {
    * Get the available ServiceCatalogSources from the komodo rest interface
    * @returns {Observable<ServiceCatalogSource[]>}
    */
-  public getAllServiceCatalogSources(): Observable<ServiceCatalogSource[]> {
+  public getAllSyndesisSources(): Observable<ServiceCatalogSource[]> {
     return Observable.of(this.serviceCatalogSources);
   }
 
@@ -143,7 +143,7 @@ export class MockConnectionService extends ConnectionService {
   }
 
   /**
-   * Create a connection in the Komodo repo - also binds the specified serviceCatalogSource
+   * Create a connection in the Komodo repo - also binds the specified syndesisSource
    * @param {NewConnection} connection the connection object
    * @returns {Observable<boolean>}
    */
@@ -152,7 +152,7 @@ export class MockConnectionService extends ConnectionService {
   }
 
   /**
-   * Update a connection in the Komodo repo - also binds the specified serviceCatalogSource.
+   * Update a connection in the Komodo repo - also binds the specified syndesisSource.
    * @param {NewConnection} connection the connection object
    * @returns {Observable<boolean>}
    */


### PR DESCRIPTION
- changes the rest method naming from 'serviceCatalogSource' to 'syndesisSource'.  Also changes corresponding messages etc to correspond to naming changes
- update the corresponding usages in the UI