### PR TITLE
ng tests should be in a profile so they can be disabled in a headless build environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
     <json-patch.version>1.9</json-patch.version>
     <kubernetes.client.version>3.1.4.fuse-710001</kubernetes.client.version>
 
-    <spring.version>4.3.12.RELEASE</spring.version>
-    <spring-boot.version>1.5.13.RELEASE</spring-boot.version>
+    <spring.version>4.3.20.RELEASE</spring.version>
+    <spring-boot.version>1.5.17.RELEASE</spring-boot.version>
     <spring-cloud.version>Dalston.SR5</spring-cloud.version>
 
     <swagger.version>1.5.19</swagger.version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -170,6 +170,7 @@
     <version.jboss.logging>3.3.0.Final</version.jboss.logging>
     <version.org.mockito>2.21.0</version.org.mockito>
     <version.com.fasterxml.jackson>2.8.9</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson.databind>2.8.11.3</version.com.fasterxml.jackson.databind>
     <org.apache.httpcomponents.version>4.5.3</org.apache.httpcomponents.version>
     <version.org.yaml>1.17</version.org.yaml>
     <version.io.fabric8.openshift-client>3.0.3</version.io.fabric8.openshift-client>
@@ -529,7 +530,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${version.com.fasterxml.jackson}</version>
+        <version>${version.com.fasterxml.jackson.databind}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -108,27 +108,6 @@
             </plugin>
             <!-- Call npm install to resolve the dependencies of the Angular UI in package.json. -->
             <plugin>
-                <artifactId>exec-maven-plugin</artifactId>
-                <groupId>org.codehaus.mojo</groupId>
-                <version>${version.exec-maven-plugin}</version>
-                <executions>
-                    <execution>
-                        <id>karmaTest</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>test</phase>
-                        <configuration>
-                            <executable>ng</executable>
-                            <arguments>
-                              <argument>test</argument>
-                              <argument>beetle-lib</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
                 <configuration>
                     <filesets>
@@ -191,6 +170,37 @@
                         <configuration>
                             <skip>true</skip>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>ng-test</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <version>${version.exec-maven-plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>karmaTest</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>test</phase>
+                                <configuration>
+                                    <executable>ng</executable>
+                                    <arguments>
+                                        <argument>test</argument>
+                                        <argument>beetle-lib</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Move ng tests into a profile so they can be disabled in a headless build environment.