### PR TITLE
TTOOLS-592 Add publishedState to rest dataservice

### DIFF
--- a/server/komodo-server/src/main/java/org/komodo/rest/relational/dataservice/RestDataservice.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/relational/dataservice/RestDataservice.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.util.Properties;
 
 import org.komodo.core.KomodoLexicon;
+import org.komodo.openshift.BuildStatus;
 import org.komodo.relational.connection.Connection;
 import org.komodo.relational.dataservice.Dataservice;
 import org.komodo.relational.resource.Driver;
@@ -75,6 +76,11 @@ public final class RestDataservice extends RestBasicEntity {
     public static final String DATASERVICE_CONNECTION_TOTAL_LABEL = "connections"; //$NON-NLS-1$
 
     /**
+     * Label used to describe dataservice published state
+     */
+    public static final String DATASERVICE_PUBLISHED_STATE_LABEL = "publishedState"; //$NON-NLS-1$
+
+    /**
      * fqn table option key
      */
     private final static String TABLE_OPTION_FQN = "teiid_rel:fqn"; //$NON-NLS-1$
@@ -125,6 +131,9 @@ public final class RestDataservice extends RestBasicEntity {
 
         Driver[] drivers = dataService.getDrivers(uow);
         setDriverTotal(drivers != null ? drivers.length : 0);
+        
+        // Initialize the published state to NOTFOUND
+        setPublishedState(BuildStatus.Status.NOTFOUND.name());
 
         addLink(new RestLink(LinkType.SELF, getUriBuilder().dataserviceUri(LinkType.SELF, settings)));
         addLink(new RestLink(LinkType.PARENT, getUriBuilder().dataserviceUri(LinkType.PARENT, settings)));
@@ -235,6 +244,21 @@ public final class RestDataservice extends RestBasicEntity {
      */
     public void setDriverTotal(int total) {
         tuples.put(DATASERVICE_DRIVER_TOTAL_LABEL, total);
+    }
+    
+    /**
+     * @return the service published state (never empty)
+     */
+    public String getPublishedState() {
+        Object publishedState = tuples.get(DATASERVICE_PUBLISHED_STATE_LABEL);
+        return publishedState != null ? publishedState.toString() : null;
+    }
+
+    /**
+     * @param publishedState the published state
+     */
+    public void setPublishedState(String publishedState) {
+        tuples.put(DATASERVICE_PUBLISHED_STATE_LABEL, publishedState);
     }
     
 }

--- a/server/komodo-server/src/test/java/org/komodo/rest/relational/RestDataserviceTest.java
+++ b/server/komodo-server/src/test/java/org/komodo/rest/relational/RestDataserviceTest.java
@@ -28,6 +28,7 @@ import javax.ws.rs.core.UriBuilder;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.komodo.openshift.BuildStatus;
 import org.komodo.relational.connection.Connection;
 import org.komodo.relational.dataservice.Dataservice;
 import org.komodo.relational.resource.Driver;
@@ -55,6 +56,7 @@ public final class RestDataserviceTest {
     private static final String SERVICE_VIEW_MODEL = "serviceViewModel";
     private static final String SERVICE_VIEW1 = "serviceView1";
     private static final String SERVICE_VIEW2 = "serviceView2";
+    private static final String DATASERVICE_PUBLISHED_STATE = BuildStatus.Status.NOTFOUND.name();
 
     private RestDataservice dataservice;
 
@@ -75,6 +77,7 @@ public final class RestDataserviceTest {
         copy.setViewDefinitionNames(this.dataservice.getViewDefinitionNames());
         copy.setDriverTotal(this.dataservice.getDriverTotal());
         copy.setConnectionTotal(this.dataservice.getConnectionTotal());
+        copy.setPublishedState(this.dataservice.getPublishedState());
 
         return copy;
     }
@@ -112,6 +115,7 @@ public final class RestDataserviceTest {
         this.dataservice.setServiceVdbName(SERVICE_VDB_NAME);
         this.dataservice.setServiceVdbVersion(SERVICE_VDB_VERSION);
         this.dataservice.setServiceViewModel(SERVICE_VIEW_MODEL);
+        this.dataservice.setPublishedState(DATASERVICE_PUBLISHED_STATE);
         String[] viewNames = new String[2];
         viewNames[0] = SERVICE_VIEW1;
         viewNames[1] = SERVICE_VIEW2;

--- a/server/komodo-server/src/test/java/org/komodo/rest/relational/json/DataserviceSerializerTest.java
+++ b/server/komodo-server/src/test/java/org/komodo/rest/relational/json/DataserviceSerializerTest.java
@@ -45,6 +45,7 @@ public final class DataserviceSerializerTest extends AbstractSerializerTest  {
         "  \"serviceVdbVersion\": \"1\"," + NEW_LINE +
         "  \"connections\": 0," + NEW_LINE +
         "  \"drivers\": 0," + NEW_LINE +
+        "  \"publishedState\": \"NOTFOUND\"," + NEW_LINE +
         "  \"keng___links\": [" + NEW_LINE +
         "    " + OPEN_BRACE + NEW_LINE +
         "      \"rel\": \"self\"," + NEW_LINE +


### PR DESCRIPTION
Adds a 'publishedState' property to the RestDataservice response.  KomodoDataserviceService uses the openshiftClient to set the published state of the dataservice VDB.  The publishedState can be one of the BuildStatus states ( NOTFOUND, SUBMITTED, CONFIGURING, BUILDING, DEPLOYING, RUNNING, FAILED, CANCELLED ).
