### PR TITLE
TTOOLS-630 Add service for validation of ViewDefinition

### DIFF
--- a/server/komodo-core/src/main/java/org/komodo/core/KomodoLexicon.java
+++ b/server/komodo-core/src/main/java/org/komodo/core/KomodoLexicon.java
@@ -1008,6 +1008,11 @@ public interface KomodoLexicon extends StringConstants {
         String DESCRIPTION = Namespace.PREFIX + COLON + "description"; //$NON-NLS-1$
         
         /**
+         * The name of the view definition DDL property. Value is {@value} .
+         */
+        String DDL = Namespace.PREFIX + COLON + "ddl"; //$NON-NLS-1$
+        
+        /**
          * The name of the view definition isComplete property. Value is {@value} .
          */
         String IS_COMPLETE = Namespace.PREFIX + COLON + "isComplete"; //$NON-NLS-1$

--- a/server/komodo-core/src/main/resources/config/komodo.cnd
+++ b/server/komodo-core/src/main/resources/config/komodo.cnd
@@ -255,6 +255,7 @@
 [tko:viewDefinition] > nt:unstructured
   - tko:viewName (string)
   - tko:description (string)
+  - tko:ddl (string)
   - tko:isComplete (boolean) = 'false' mandatory autocreated
   - tko:sourcePaths (string) multiple
   + tko:sqlCompositions (tko:sqlCompositions)

--- a/server/komodo-relational/src/main/java/org/komodo/relational/ServiceVdbGenerator.java
+++ b/server/komodo-relational/src/main/java/org/komodo/relational/ServiceVdbGenerator.java
@@ -140,7 +140,11 @@ public final class ServiceVdbGenerator implements TeiidSqlConstants.Tokens {
             	if( viewDef.isComplete(uow) ) {
             		TableInfo[] tableInfos = getSourceTableInfos(uow, viewDef);
 
-            		String viewDdl = getODataViewDdl(uow, viewDef, tableInfos);
+            		// If user has supplied DDL, use it.  (Assume it has already been validated)
+            		String viewDdl = viewDef.getDdl(uow);
+            		if(viewDdl == null || viewDdl.length() < 1) {
+                		viewDdl = getODataViewDdl(uow, viewDef, tableInfos);
+            		}
             		allViewDdl.append(viewDdl).append(NEW_LINE);
    
             		// Add sources to list if not already present

--- a/server/komodo-relational/src/main/java/org/komodo/relational/profile/SqlComposition.java
+++ b/server/komodo-relational/src/main/java/org/komodo/relational/profile/SqlComposition.java
@@ -51,7 +51,7 @@ public interface SqlComposition  extends RelationalObject, StringConstants {
 
 
     /**
-     * The resolver of a {@link ViewDefinition}.
+     * The resolver of a {@link SqlComposition}.
      */
     TypeResolver<SqlComposition> RESOLVER = new TypeResolver<SqlComposition>() {
 

--- a/server/komodo-relational/src/main/java/org/komodo/relational/profile/SqlProjectedColumn.java
+++ b/server/komodo-relational/src/main/java/org/komodo/relational/profile/SqlProjectedColumn.java
@@ -51,7 +51,7 @@ public interface SqlProjectedColumn  extends RelationalObject, StringConstants {
 
 
     /**
-     * The resolver of a {@link ViewDefinition}.
+     * The resolver of a {@link SqlProjectedColumn}.
      */
     TypeResolver<SqlProjectedColumn> RESOLVER = new TypeResolver<SqlProjectedColumn>() {
 

--- a/server/komodo-relational/src/main/java/org/komodo/relational/profile/ViewDefinition.java
+++ b/server/komodo-relational/src/main/java/org/komodo/relational/profile/ViewDefinition.java
@@ -171,6 +171,24 @@ public interface ViewDefinition  extends RelationalObject, StringConstants {
     /**
      * @param transaction
      *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @return the view DDL
+     * @throws KException
+     *         if an error occurs
+     */
+    String getDdl(final UnitOfWork transaction) throws KException;
+    
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param ddl value of view ddl
+     * @throws KException
+     *         if an error occurs         
+     */
+    void setDdl(final UnitOfWork transaction, String ddl) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
      * @param complete value for isComplete
      * @throws KException
      *         if an error occurs         

--- a/server/komodo-relational/src/main/java/org/komodo/relational/profile/internal/ViewDefinitionImpl.java
+++ b/server/komodo-relational/src/main/java/org/komodo/relational/profile/internal/ViewDefinitionImpl.java
@@ -200,6 +200,16 @@ public class ViewDefinitionImpl extends RelationalObjectImpl implements ViewDefi
 	}
 
 	@Override
+	public String getDdl(UnitOfWork transaction) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+        
+        String desc = getObjectProperty(transaction, PropertyValueType.STRING, "getDdl", //$NON-NLS-1$
+                KomodoLexicon.ViewDefinition.DDL );
+		return desc;
+	}
+
+	@Override
 	public String[] getSourcePaths(UnitOfWork transaction,
             final String... namePatterns ) throws KException {
         ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
@@ -250,6 +260,11 @@ public class ViewDefinitionImpl extends RelationalObjectImpl implements ViewDefi
 	@Override
 	public void setDescription(UnitOfWork transaction, String description) throws KException {
 		setObjectProperty( transaction, "setDescription", KomodoLexicon.ViewDefinition.DESCRIPTION, description ); //$NON-NLS-1$
+	}
+
+	@Override
+	public void setDdl(UnitOfWork transaction, String ddl) throws KException {
+		setObjectProperty( transaction, "setDdl", KomodoLexicon.ViewDefinition.DDL, ddl ); //$NON-NLS-1$
 	}
 
 	@Override

--- a/server/komodo-server/src/main/java/org/komodo/rest/KomodoRestV1Application.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/KomodoRestV1Application.java
@@ -608,6 +608,11 @@ public class KomodoRestV1Application implements SystemConstants {
          * Refresh views referenced in a view editor state object
          */
         String REFRESH_DATASERVICE_VIEWS = "refreshViews";
+        
+        /**
+         * Validate a ViewDefintion
+         */
+        String VALIDATE_VIEW_DEFINITION = "validateViewDefinition";
     }
 
 

--- a/server/komodo-server/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -1531,6 +1531,21 @@ public final class RelationalMessages {
         PUBLISH_ERROR,
 
         /**
+         * An error indicating a view definition is missing the name
+         */
+        VIEW_DEFINITION_MISSING_NAME,
+
+        /**
+         * An error indicating a view definition is missing the DDL
+         */
+        VIEW_DEFINITION_MISSING_DDL,
+
+        /**
+         * An error indicating a problem with validating the viewDefinition DDL
+         */
+        VALIDATE_VIEW_DEFINITION_ERROR,
+
+        /**
          * VDB Not found
          */
         VDB_NOT_FOUND,

--- a/server/komodo-server/src/main/java/org/komodo/rest/relational/json/ViewDefinitionSerializer.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/relational/json/ViewDefinitionSerializer.java
@@ -48,6 +48,10 @@ public class ViewDefinitionSerializer extends TypeAdapter<RestViewDefinition> {
 			out.name(RestViewEditorState.DESCRIPTION);
 			out.value(restViewDef.getDescription());
 		}
+		if( restViewDef.getDdl() != null ) {
+			out.name(RestViewEditorState.DDL);
+			out.value(restViewDef.getDdl());
+		}
 		
 		out.name(RestViewEditorState.IS_COMPLETE);
 		out.value(restViewDef.isComplete());
@@ -100,6 +104,9 @@ public class ViewDefinitionSerializer extends TypeAdapter<RestViewDefinition> {
                     break;
                 case RestViewEditorState.DESCRIPTION:
                 	viewDef.setDescription(in.nextString());
+                    break;
+                case RestViewEditorState.DDL:
+                	viewDef.setDdl(in.nextString());
                     break;
                 case RestViewEditorState.SOURCE_PATHS:
                     String[] sourcePaths = BUILDER.fromJson(in, String[].class);

--- a/server/komodo-server/src/main/java/org/komodo/rest/relational/json/ViewDefinitionStatusSerializer.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/relational/json/ViewDefinitionStatusSerializer.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags and
+ * the COPYRIGHT.txt file distributed with this work.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.komodo.rest.relational.json;
+
+import static org.komodo.rest.Messages.Error.UNEXPECTED_JSON_TOKEN;
+
+import java.io.IOException;
+
+import org.komodo.rest.Messages;
+import org.komodo.rest.relational.response.vieweditorstate.RestViewDefinitionStatus;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * A GSON serializer/deserializer for {@status RestViewDefinitionStatus}s.
+ */
+public final class ViewDefinitionStatusSerializer extends TypeAdapter< RestViewDefinitionStatus > {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see com.google.gson.TypeAdapter#read(com.google.gson.stream.JsonReader)
+     */
+    @Override
+    public RestViewDefinitionStatus read( final JsonReader in ) throws IOException {
+        final RestViewDefinitionStatus status = new RestViewDefinitionStatus();
+        in.beginObject();
+
+        while ( in.hasNext() ) {
+            final String name = in.nextName();
+
+            switch ( name ) {
+                case RestViewDefinitionStatus.STATUS_LABEL:
+                    status.setStatus(in.nextString());
+                    break;
+                case RestViewDefinitionStatus.MESSAGE_LABEL:
+                    status.setMessage(in.nextString());
+                    break;
+                default:
+                    throw new IOException( Messages.getString( UNEXPECTED_JSON_TOKEN, name ) );
+            }
+        }
+
+        in.endObject();
+
+        return status;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see com.google.gson.TypeAdapter#write(com.google.gson.stream.JsonWriter, java.lang.Object)
+     */
+    @Override
+    public void write( final JsonWriter out,
+                       final RestViewDefinitionStatus value ) throws IOException {
+
+        out.beginObject();
+
+        // Status of object
+        out.name(RestViewDefinitionStatus.STATUS_LABEL);
+        out.value(value.getStatus());
+
+        // Status of object
+        out.name(RestViewDefinitionStatus.MESSAGE_LABEL);
+        out.value(value.getMessage());
+
+        out.endObject();
+    }
+
+}

--- a/server/komodo-server/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestViewDefinition.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestViewDefinition.java
@@ -63,6 +63,9 @@ public class RestViewDefinition extends RestBasicEntity {
         if( viewDef.getDescription() != null ) {
         	tuples.put(RestViewEditorState.DESCRIPTION, viewDef.getDescription());
         }
+        if( viewDef.getDdl() != null ) {
+        	tuples.put(RestViewEditorState.DDL, viewDef.getDdl());
+        }
         
         setComplete(viewDef.isComplete());
         
@@ -103,6 +106,9 @@ public class RestViewDefinition extends RestBasicEntity {
         }
         if( viewDef.getDescription(transaction) != null ) {
         	tuples.put(RestViewEditorState.DESCRIPTION, viewDef.getDescription(transaction));
+        }
+        if( viewDef.getDdl(transaction) != null ) {
+        	tuples.put(RestViewEditorState.DDL, viewDef.getDdl(transaction));
         }
         
         setComplete(viewDef.isComplete(transaction));
@@ -157,6 +163,22 @@ public class RestViewDefinition extends RestBasicEntity {
      */
     public void setDescription(final String description) {
         tuples.put(RestViewEditorState.DESCRIPTION, description);
+    }
+
+    /**
+     * @return the view DDL (can be empty)
+     */
+    public String getDdl() {
+        Object result = tuples.get(RestViewEditorState.DDL);
+        return result != null ? result.toString() : null;
+    }
+
+    /**
+     * @param ddl
+     *        the new DDL (can be empty)
+     */
+    public void setDdl(final String ddl) {
+        tuples.put(RestViewEditorState.DDL, ddl);
     }
     
     /**

--- a/server/komodo-server/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestViewDefinitionStatus.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestViewDefinitionStatus.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags and
+ * the COPYRIGHT.txt file distributed with this work.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.komodo.rest.relational.response.vieweditorstate;
+
+import javax.ws.rs.core.MediaType;
+
+import org.komodo.rest.KRestEntity;
+import org.komodo.utils.ArgCheck;
+
+
+/**
+ * Object to be serialised by GSON that provides view definition status
+ */
+public class RestViewDefinitionStatus implements KRestEntity {
+
+    /**
+     * Label for the title
+     */
+    public static final String STATUS_LABEL = "status"; //$NON-NLS-1$
+
+    /**
+     * Label for the message
+     */
+    public static final String MESSAGE_LABEL = "message"; //$NON-NLS-1$
+
+    private String status;
+
+    private String message;
+
+    /**
+     * Default constructor for deserialization
+     */
+    public RestViewDefinitionStatus() {
+        // do nothing
+    }
+
+    /**
+     * @param title the subject of this status object
+     *
+     */
+    public RestViewDefinitionStatus(String status) {
+        ArgCheck.isNotNull(status);
+        this.status = status;
+    }
+
+    @Override
+    public boolean supports(MediaType mediaType) {
+        return MediaType.APPLICATION_JSON_TYPE.equals(mediaType);
+    }
+
+    @Override
+    public Object getXml() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @return the status
+     */
+    public String getStatus() {
+        return this.status;
+    }
+
+    /**
+     * @param status the status
+     */
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    /**
+     * @return the message
+     */
+    public String getMessage() {
+        return this.message;
+    }
+
+    /**
+     * @param message the message
+     */
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((this.status == null) ? 0 : this.status.hashCode());
+        result = prime * result + ((this.message == null) ? 0 : this.message.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        RestViewDefinitionStatus other = (RestViewDefinitionStatus)obj;
+        if (this.status == null) {
+            if (other.status != null)
+                return false;
+        } else
+            if (!this.status.equals(other.status))
+                return false;
+        if (this.message == null) {
+            if (other.message != null)
+                return false;
+        } else
+            if (!this.message.equals(other.message))
+                return false;
+        return true;
+    }
+
+    @SuppressWarnings( "nls" )
+    @Override
+    public String toString() {
+        return "RestViewDefinitionStatus [status=" + this.status + ", message=" + this.message + "]";
+    }
+}

--- a/server/komodo-server/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-server/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -320,6 +320,9 @@ Error.PROFILE_EDITOR_STATE_GET_ERROR = An error occurred while getting a view ed
 Error.PROFILE_EDITOR_STATES_GET_ERROR = An error occurred while getting view editor states
 Error.PROFILE_EDITOR_STATE_CREATE_ERROR = An error occurred while storing a view editor state: %s
 Error.PROFILE_EDITOR_STATE_REMOVE_ERROR = An error occurred while removing a view editor state: %s
+Error.VIEW_DEFINITION_MISSING_NAME=The view definition name is missing
+Error.VIEW_DEFINITION_MISSING_DDL=The view definition DDL is missing
+Error.VALIDATE_VIEW_DEFINITION_ERROR=An error occurred while validating the view definition
 
 Error.PUBLISH_ERROR = An error occurred during the publish operation: %s
 Error.VDB_NOT_FOUND = VDB name not provided


### PR DESCRIPTION
- Adds DDL property to the ViewDefinition.  This will allow the user to provide their own DDL for the view.
- In the ServiceVdbGenerator -  if the view DDL is provided, it is used - rather than generating the DDL
- added a new service method in KomodoUtilService to validate a ViewDefinition.  This method takes the DDL from the supplied ViewDefinition and validates it.  This service method needs work - the DDL importer is throwing and exception so the response it not consistent currently.