### PR TITLE
TTOOLS-661 ViewDefinition improvement

### DIFF
--- a/server/komodo-core/src/main/java/org/komodo/core/KomodoLexicon.java
+++ b/server/komodo-core/src/main/java/org/komodo/core/KomodoLexicon.java
@@ -1016,6 +1016,11 @@ public interface KomodoLexicon extends StringConstants {
          * The name of the view definition isComplete property. Value is {@value} .
          */
         String IS_COMPLETE = Namespace.PREFIX + COLON + "isComplete"; //$NON-NLS-1$
+
+        /**
+         * The name of the view definition isUserDefined property. Value is {@value} .
+         */
+        String IS_USER_DEFINED = Namespace.PREFIX + COLON + "isUserDefined"; //$NON-NLS-1$
         
         /**
          * The name of the view definition source paths container property. Value is {@value} .

--- a/server/komodo-core/src/main/resources/config/komodo.cnd
+++ b/server/komodo-core/src/main/resources/config/komodo.cnd
@@ -257,6 +257,7 @@
   - tko:description (string)
   - tko:ddl (string)
   - tko:isComplete (boolean) = 'false' mandatory autocreated
+  - tko:isUserDefined (boolean) = 'false' mandatory autocreated
   - tko:sourcePaths (string) multiple
   + tko:sqlCompositions (tko:sqlCompositions)
   + tko:projectedColumns (tko:projectedColumns)

--- a/server/komodo-relational/src/main/java/org/komodo/relational/ServiceVdbGenerator.java
+++ b/server/komodo-relational/src/main/java/org/komodo/relational/ServiceVdbGenerator.java
@@ -140,10 +140,13 @@ public final class ServiceVdbGenerator implements TeiidSqlConstants.Tokens {
             	if( viewDef.isComplete(uow) ) {
             		TableInfo[] tableInfos = getSourceTableInfos(uow, viewDef);
 
-            		// If user has supplied DDL, use it.  (Assume it has already been validated)
-            		String viewDdl = viewDef.getDdl(uow);
-            		if(viewDdl == null || viewDdl.length() < 1) {
+            		// If the ViewDefinition is not user defined, regen the DDL
+            		String viewDdl = null;
+            		if(!viewDef.isUserDefined(uow)) {
                 		viewDdl = getODataViewDdl(uow, viewDef, tableInfos);
+                		viewDef.setDdl(uow, viewDdl);
+            		} else {
+            			viewDdl = viewDef.getDdl(uow);
             		}
             		allViewDdl.append(viewDdl).append(NEW_LINE);
    

--- a/server/komodo-relational/src/main/java/org/komodo/relational/profile/ViewDefinition.java
+++ b/server/komodo-relational/src/main/java/org/komodo/relational/profile/ViewDefinition.java
@@ -203,6 +203,24 @@ public interface ViewDefinition  extends RelationalObject, StringConstants {
      *         if an error occurs         
      */
     boolean isComplete(final UnitOfWork transaction) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param userDefined value for isUserDefined
+     * @throws KException
+     *         if an error occurs         
+     */
+    void setUserDefined(final UnitOfWork transaction, boolean userDefined) throws KException;
+    
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @return boolean value of isUserDefined
+     * @throws KException
+     *         if an error occurs         
+     */
+    boolean isUserDefined(final UnitOfWork transaction) throws KException;
     
     /**
      * @param transaction

--- a/server/komodo-relational/src/main/java/org/komodo/relational/profile/internal/ViewDefinitionImpl.java
+++ b/server/komodo-relational/src/main/java/org/komodo/relational/profile/internal/ViewDefinitionImpl.java
@@ -349,6 +349,21 @@ public class ViewDefinitionImpl extends RelationalObjectImpl implements ViewDefi
 		return value;
 	}
 
+	@Override
+	public void setUserDefined(UnitOfWork transaction, boolean userDefined) throws KException {
+		setObjectProperty( transaction, "setUserDefined", KomodoLexicon.ViewDefinition.IS_USER_DEFINED, userDefined ); //$NON-NLS-1$
+	}
+
+	@Override
+	public boolean isUserDefined(UnitOfWork transaction) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+        
+        final Boolean value = getObjectProperty(transaction, PropertyValueType.BOOLEAN, "isUserDefined", //$NON-NLS-1$
+                                                             KomodoLexicon.ViewDefinition.IS_USER_DEFINED );
+		return value;
+	}
+
     /**
      * {@inheritDoc}
      *

--- a/server/komodo-server/src/main/java/org/komodo/rest/relational/json/ViewDefinitionSerializer.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/relational/json/ViewDefinitionSerializer.java
@@ -55,6 +55,9 @@ public class ViewDefinitionSerializer extends TypeAdapter<RestViewDefinition> {
 		
 		out.name(RestViewEditorState.IS_COMPLETE);
 		out.value(restViewDef.isComplete());
+
+		out.name(RestViewEditorState.IS_USER_DEFINED);
+		out.value(restViewDef.isUserDefined());
 		
 		if( restViewDef.getSourcePaths() != null ) {
 			out.name(RestViewEditorState.SOURCE_PATHS);
@@ -114,6 +117,9 @@ public class ViewDefinitionSerializer extends TypeAdapter<RestViewDefinition> {
                     break;
                 case RestViewEditorState.IS_COMPLETE:
                     viewDef.setComplete(in.nextBoolean());
+                    break;
+                case RestViewEditorState.IS_USER_DEFINED:
+                    viewDef.setUserDefined(in.nextBoolean());
                     break;
                 case RestViewEditorState.COMPOSITIONS_LABEL:
                     RestSqlComposition[] comps = BUILDER.fromJson(in, RestSqlComposition[].class);

--- a/server/komodo-server/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestViewDefinition.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestViewDefinition.java
@@ -68,6 +68,7 @@ public class RestViewDefinition extends RestBasicEntity {
         }
         
         setComplete(viewDef.isComplete());
+        setUserDefined(viewDef.isUserDefined());
         
         String[] paths = viewDef.getSourcePaths();
         if( paths != null && paths.length > 0 ) {
@@ -112,6 +113,7 @@ public class RestViewDefinition extends RestBasicEntity {
         }
         
         setComplete(viewDef.isComplete(transaction));
+        setUserDefined(viewDef.isUserDefined(transaction));
         
         String[] paths = viewDef.getSourcePaths(transaction);
         if( paths != null && paths.length > 0 ) {
@@ -195,6 +197,22 @@ public class RestViewDefinition extends RestBasicEntity {
      */
     public void setComplete(final boolean complete) {
         tuples.put(RestViewEditorState.IS_COMPLETE, complete);
+    }
+
+    /**
+     * @return the view definition isUserDefined status
+     */
+    public boolean isUserDefined() {
+        Object hasIsUserDefined = tuples.get(RestViewEditorState.IS_USER_DEFINED);
+        return hasIsUserDefined != null ? Boolean.parseBoolean(hasIsUserDefined.toString()) : false;
+    }
+
+    /**
+     * @param userDefined 
+     *        the userDefined status
+     */
+    public void setUserDefined(final boolean userDefined) {
+        tuples.put(RestViewEditorState.IS_USER_DEFINED, userDefined);
     }
     
     /**

--- a/server/komodo-server/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestViewEditorState.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/relational/response/vieweditorstate/RestViewEditorState.java
@@ -58,6 +58,11 @@ public class RestViewEditorState extends AbstractKEntity {
      * isComplete property
      */
     public static final String IS_COMPLETE = "isComplete"; //$NON-NLS-1$
+
+    /**
+     * isUserDefined property
+     */
+    public static final String IS_USER_DEFINED = "isUserDefined"; //$NON-NLS-1$
     
     /**
      * Label used for view definition source table paths array

--- a/server/komodo-server/src/main/java/org/komodo/rest/service/KomodoUtilService.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/service/KomodoUtilService.java
@@ -1111,6 +1111,7 @@ public final class KomodoUtilService extends KomodoService {
             viewDefn.addSourcePath(uow, restSourcePath);
         }
         viewDefn.setComplete(uow, restViewDefn.isComplete());
+        viewDefn.setUserDefined(uow, restViewDefn.isUserDefined());
         // Compositions
         for (RestSqlComposition restComp: restViewDefn.getSqlCompositions()) {
             SqlComposition sqlComp = viewDefn.addSqlComposition(uow, restComp.getId());

--- a/server/komodo-server/src/test/java/org/komodo/rest/relational/json/ViewEditorStateSerializerTest.java
+++ b/server/komodo-server/src/test/java/org/komodo/rest/relational/json/ViewEditorStateSerializerTest.java
@@ -49,6 +49,7 @@ public class ViewEditorStateSerializerTest extends AbstractSerializerTest {
     private String viewDefinitionName = "testView";
     private String description = "test view description text";
     private boolean isComplete = true;
+    private boolean isUserDefined = false;
     private String sourceTablePath1 = "path/to/source1";
     private String sourceTablePath2 = "path/to/source2";
     private String sourceTablePath3 = "path/to/source3";
@@ -87,6 +88,7 @@ public class ViewEditorStateSerializerTest extends AbstractSerializerTest {
                 	tab(2) + q(RestViewEditorState.ID_VIEW_NAME) + colon() + q(viewDefinitionName) + pnl(COMMA) +
                 	tab(2) + q(RestViewEditorState.DESCRIPTION) + colon() + q(description) + pnl(COMMA) +
                 	tab(2) + q(RestViewEditorState.IS_COMPLETE) + colon() + isComplete + pnl(COMMA) +
+                	tab(2) + q(RestViewEditorState.IS_USER_DEFINED) + colon() + isUserDefined + pnl(COMMA) +
                 	tab(2) + q(RestViewEditorState.SOURCE_PATHS) + colon() + pnl(OPEN_SQUARE_BRACKET) +
                 		tab(3) + q(sourceTablePath1) + pnl(COMMA) +
                 		tab(3) + q(sourceTablePath2) + pnl(COMMA) +
@@ -249,6 +251,7 @@ public class ViewEditorStateSerializerTest extends AbstractSerializerTest {
         when(viewDef.getViewName(transaction)).thenReturn(viewDefinitionName);
         when(viewDef.getDescription(transaction)).thenReturn(description);
         when(viewDef.isComplete(transaction)).thenReturn(isComplete);
+        when(viewDef.isUserDefined(transaction)).thenReturn(isUserDefined);
         when(viewDef.getSourcePaths(transaction)).thenReturn(sourceTablePaths);
         
         // Mocks for Compositions


### PR DESCRIPTION
[has corresponding PR in syndesis UI]

Adds 'isUserDefined' property on the ViewDefinition.
- If false, the ServiceVdbGenerator will generate DDL from the ViewDefinition settings and reset its DDL
- If true, the DDL is not generated - the DDL value is used as is.
