### PR TITLE
TT-668: Only generate DDL for a single table even when multiple are s…

### DIFF
--- a/server/komodo-relational/src/main/java/org/komodo/relational/ServiceVdbGenerator.java
+++ b/server/komodo-relational/src/main/java/org/komodo/relational/ServiceVdbGenerator.java
@@ -239,8 +239,9 @@ public final class ServiceVdbGenerator implements TeiidSqlConstants.Tokens {
         sb.append("RowId long PRIMARY KEY, "); //$NON-NLS-1$
 
         // Check for join and single or 2 source join
-        boolean isJoin = sourceTableInfos.length > 1;
-        boolean singleTable = sourceTableInfos.length == 1;
+        // Disable join for Syndesis 7.4 DDL generation. 
+        boolean isJoin = false; // sourceTableInfos.length > 1;
+        boolean singleTable = true; // sourceTableInfos.length == 1;
         
         TableInfo lhTableInfo = sourceTableInfos[0];
         TableInfo rhTableInfo = null;

--- a/server/komodo-relational/src/test/java/org/komodo/relational/ServiceVdbGeneratorTest.java
+++ b/server/komodo-relational/src/test/java/org/komodo/relational/ServiceVdbGeneratorTest.java
@@ -425,7 +425,8 @@ public class ServiceVdbGeneratorTest extends RelationalModelTest {
     	String EXPECTED_DDL = EXPECTED_JOIN_SQL_SINGE_SOURCE_START + INNER_JOIN_STR + EXPECTED_JOIN_SQL_SINGLE_SOURCE_END;
         String viewDdl = helpGenerateDdlForWithJoinType(sourceTablePath2, ServiceVdbGenerator.JOIN_INNER, true, true);
         printResults(EXPECTED_DDL, viewDdl);
-        assertThat(viewDdl, is(EXPECTED_DDL));
+        // TODO Uncomment after JOINs are working
+        // assertThat(viewDdl, is(EXPECTED_DDL));
     }
     
     @Test
@@ -433,7 +434,8 @@ public class ServiceVdbGeneratorTest extends RelationalModelTest {
     	String EXPECTED_DDL = EXPECTED_JOIN_SQL_SINGE_SOURCE_START + INNER_JOIN_STR + EXPECTED_JOIN_SQL_SINGLE_SOURCE_END;
         String viewDdl = helpGenerateDdlForWithJoinType(sourceTablePath2, ServiceVdbGenerator.JOIN_INNER, true, false);
         printResults(EXPECTED_DDL, viewDdl);
-        assertThat(viewDdl, is(EXPECTED_DDL));
+        // TODO Uncomment after JOINs are working
+        // assertThat(viewDdl, is(EXPECTED_DDL));
     }
     
     @Test
@@ -441,7 +443,8 @@ public class ServiceVdbGeneratorTest extends RelationalModelTest {
     	String EXPECTED_DDL = EXPECTED_JOIN_SQL_SINGE_SOURCE_START + LEFT_OUTER_JOIN_STR + EXPECTED_JOIN_SQL_SINGLE_SOURCE_END;
         String viewDdl = helpGenerateDdlForWithJoinType(sourceTablePath2, ServiceVdbGenerator.JOIN_LEFT_OUTER, true, true);
         printResults(EXPECTED_DDL, viewDdl);
-        assertThat(viewDdl, is(EXPECTED_DDL));
+        // TODO Uncomment after JOINs are working
+        // assertThat(viewDdl, is(EXPECTED_DDL));
     }
     
     @Test
@@ -449,7 +452,8 @@ public class ServiceVdbGeneratorTest extends RelationalModelTest {
     	String EXPECTED_DDL = EXPECTED_JOIN_SQL_SINGE_SOURCE_START + LEFT_OUTER_JOIN_STR + EXPECTED_JOIN_SQL_SINGLE_SOURCE_END;
         String viewDdl = helpGenerateDdlForWithJoinType(sourceTablePath2, ServiceVdbGenerator.JOIN_LEFT_OUTER, true, false);
         printResults(EXPECTED_DDL, viewDdl);
-        assertThat(viewDdl, is(EXPECTED_DDL));
+        // TODO Uncomment after JOINs are working
+        // assertThat(viewDdl, is(EXPECTED_DDL));
     }
     
     @Test
@@ -457,7 +461,8 @@ public class ServiceVdbGeneratorTest extends RelationalModelTest {
     	String EXPECTED_DDL = EXPECTED_JOIN_SQL_SINGE_SOURCE_START + RIGHT_OUTER_JOIN_STR + EXPECTED_JOIN_SQL_SINGLE_SOURCE_END;
         String viewDdl = helpGenerateDdlForWithJoinType(sourceTablePath2, ServiceVdbGenerator.JOIN_RIGHT_OUTER, true, true);
         printResults(EXPECTED_DDL, viewDdl);
-        assertThat(viewDdl, is(EXPECTED_DDL));
+        // TODO Uncomment after JOINs are working
+        // assertThat(viewDdl, is(EXPECTED_DDL));
     }
     
     @Test
@@ -465,7 +470,8 @@ public class ServiceVdbGeneratorTest extends RelationalModelTest {
     	String EXPECTED_DDL = EXPECTED_JOIN_SQL_SINGE_SOURCE_START + RIGHT_OUTER_JOIN_STR + EXPECTED_JOIN_SQL_SINGLE_SOURCE_END;
         String viewDdl = helpGenerateDdlForWithJoinType(sourceTablePath2, ServiceVdbGenerator.JOIN_RIGHT_OUTER, true, false);
         printResults(EXPECTED_DDL, viewDdl);
-        assertThat(viewDdl, is(EXPECTED_DDL));
+        // TODO Uncomment after JOINs are working
+        // assertThat(viewDdl, is(EXPECTED_DDL));
     }
     
     @Test
@@ -473,7 +479,8 @@ public class ServiceVdbGeneratorTest extends RelationalModelTest {
     	String EXPECTED_DDL = EXPECTED_JOIN_SQL_SINGE_SOURCE_START + FULL_OUTER_JOIN_STR + EXPECTED_JOIN_SQL_SINGLE_SOURCE_END;
         String viewDdl = helpGenerateDdlForWithJoinType(sourceTablePath2, ServiceVdbGenerator.JOIN_FULL_OUTER, true, true);
         printResults(EXPECTED_DDL, viewDdl);
-        assertThat(viewDdl, is(EXPECTED_DDL));
+        // TODO Uncomment after JOINs are working
+        // assertThat(viewDdl, is(EXPECTED_DDL));
     }
     
     @Test
@@ -481,7 +488,8 @@ public class ServiceVdbGeneratorTest extends RelationalModelTest {
     	String EXPECTED_DDL = EXPECTED_JOIN_SQL_SINGE_SOURCE_START + FULL_OUTER_JOIN_STR + EXPECTED_JOIN_SQL_SINGLE_SOURCE_END;
         String viewDdl = helpGenerateDdlForWithJoinType(sourceTablePath2, ServiceVdbGenerator.JOIN_FULL_OUTER, true, false);
         printResults(EXPECTED_DDL, viewDdl);
-        assertThat(viewDdl, is(EXPECTED_DDL));
+        // TODO Uncomment after JOINs are working
+        // assertThat(viewDdl, is(EXPECTED_DDL));
     }
     
     @Test
@@ -489,7 +497,8 @@ public class ServiceVdbGeneratorTest extends RelationalModelTest {
     	String EXPECTED_DDL = EXPECTED_JOIN_SQL_TWO_SOURCES_START + INNER_JOIN_STR + EXPECTED_JOIN_SQL_TWO_SOURCES_END;
         String viewDdl = helpGenerateDdlForWithJoinType(sourceTablePath3, ServiceVdbGenerator.JOIN_INNER, false, true);
         printResults(EXPECTED_DDL, viewDdl);
-        assertThat(viewDdl, is(EXPECTED_DDL));
+        // TODO Uncomment after JOINs are working
+        // assertThat(viewDdl, is(EXPECTED_DDL));
     }
     
     @Test
@@ -497,7 +506,8 @@ public class ServiceVdbGeneratorTest extends RelationalModelTest {
     	String EXPECTED_DDL = EXPECTED_JOIN_SQL_TWO_SOURCES_START + INNER_JOIN_STR + EXPECTED_JOIN_SQL_TWO_SOURCES_END;
         String viewDdl = helpGenerateDdlForWithJoinType(sourceTablePath3, ServiceVdbGenerator.JOIN_INNER, false, false);
         printResults(EXPECTED_DDL, viewDdl);
-        assertThat(viewDdl, is(EXPECTED_DDL));
+        // TODO Uncomment after JOINs are working
+        // assertThat(viewDdl, is(EXPECTED_DDL));
     }
     
     @Test
@@ -505,7 +515,8 @@ public class ServiceVdbGeneratorTest extends RelationalModelTest {
     	String EXPECTED_DDL = EXPECTED_JOIN_SQL_TWO_SOURCES_START + LEFT_OUTER_JOIN_STR + EXPECTED_JOIN_SQL_TWO_SOURCES_END;
         String viewDdl = helpGenerateDdlForWithJoinType(sourceTablePath3, ServiceVdbGenerator.JOIN_LEFT_OUTER, false, true);
         printResults(EXPECTED_DDL, viewDdl);
-        assertThat(viewDdl, is(EXPECTED_DDL));
+        // TODO Uncomment after JOINs are working
+        // assertThat(viewDdl, is(EXPECTED_DDL));
     }
     
     @Test
@@ -513,7 +524,8 @@ public class ServiceVdbGeneratorTest extends RelationalModelTest {
     	String EXPECTED_DDL = EXPECTED_JOIN_SQL_TWO_SOURCES_START + LEFT_OUTER_JOIN_STR + EXPECTED_JOIN_SQL_TWO_SOURCES_END;
         String viewDdl = helpGenerateDdlForWithJoinType(sourceTablePath3, ServiceVdbGenerator.JOIN_LEFT_OUTER, false, false);
         printResults(EXPECTED_DDL, viewDdl);
-        assertThat(viewDdl, is(EXPECTED_DDL));
+        // TODO Uncomment after JOINs are working
+        // assertThat(viewDdl, is(EXPECTED_DDL));
     }
     
     @Test
@@ -521,7 +533,8 @@ public class ServiceVdbGeneratorTest extends RelationalModelTest {
     	String EXPECTED_DDL = EXPECTED_JOIN_SQL_TWO_SOURCES_START + RIGHT_OUTER_JOIN_STR + EXPECTED_JOIN_SQL_TWO_SOURCES_END;
         String viewDdl = helpGenerateDdlForWithJoinType(sourceTablePath3, ServiceVdbGenerator.JOIN_RIGHT_OUTER, false, true);
         printResults(EXPECTED_DDL, viewDdl);
-        assertThat(viewDdl, is(EXPECTED_DDL));
+        // TODO Uncomment after JOINs are working
+        // assertThat(viewDdl, is(EXPECTED_DDL));
     }
     
     @Test
@@ -529,7 +542,8 @@ public class ServiceVdbGeneratorTest extends RelationalModelTest {
     	String EXPECTED_DDL = EXPECTED_JOIN_SQL_TWO_SOURCES_START + RIGHT_OUTER_JOIN_STR + EXPECTED_JOIN_SQL_TWO_SOURCES_END;
         String viewDdl = helpGenerateDdlForWithJoinType(sourceTablePath3, ServiceVdbGenerator.JOIN_RIGHT_OUTER, false, false);
         printResults(EXPECTED_DDL, viewDdl);
-        assertThat(viewDdl, is(EXPECTED_DDL));
+        // TODO Uncomment after JOINs are working
+        // assertThat(viewDdl, is(EXPECTED_DDL));
     }
     
     @Test
@@ -537,7 +551,8 @@ public class ServiceVdbGeneratorTest extends RelationalModelTest {
     	String EXPECTED_DDL = EXPECTED_JOIN_SQL_TWO_SOURCES_START + FULL_OUTER_JOIN_STR + EXPECTED_JOIN_SQL_TWO_SOURCES_END;
         String viewDdl = helpGenerateDdlForWithJoinType(sourceTablePath3, ServiceVdbGenerator.JOIN_FULL_OUTER, false, true);
         printResults(EXPECTED_DDL, viewDdl);
-        assertThat(viewDdl, is(EXPECTED_DDL));
+        // TODO Uncomment after JOINs are working
+        // assertThat(viewDdl, is(EXPECTED_DDL));
     }
     
     @Test
@@ -545,7 +560,8 @@ public class ServiceVdbGeneratorTest extends RelationalModelTest {
     	String EXPECTED_DDL = EXPECTED_JOIN_SQL_TWO_SOURCES_START + FULL_OUTER_JOIN_STR + EXPECTED_JOIN_SQL_TWO_SOURCES_END;
         String viewDdl = helpGenerateDdlForWithJoinType(sourceTablePath3, ServiceVdbGenerator.JOIN_FULL_OUTER, false, false);
         printResults(EXPECTED_DDL, viewDdl);
-        assertThat(viewDdl, is(EXPECTED_DDL));
+        // TODO Uncomment after JOINs are working
+        // assertThat(viewDdl, is(EXPECTED_DDL));
     }
     
     @Test


### PR DESCRIPTION
…elected. Saving the tables included in the view creation wizard will allow validation to consider all table selected so the user can manulaly add and validate their query.