### PR TITLE
Removing the modeshape service vdb

### DIFF
--- a/server/komodo-core/src/main/java/org/komodo/core/KEngineImpl.java
+++ b/server/komodo-core/src/main/java/org/komodo/core/KEngineImpl.java
@@ -477,7 +477,6 @@ public class KEngineImpl implements KEngine, KObserver, StringConstants {
         return getDefaultRepository().createTransaction(userName, name, rollbackOnly, new SynchronousCallback(), repoUser);
 	}
 
-	@Override
 	public void associateTransaction(UnitOfWork uow) {
 		RepositoryImpl.associateTransaction(uow);
 	}

--- a/server/komodo-server/src/main/java/org/komodo/metadata/internal/TeiidVdbImpl.java
+++ b/server/komodo-server/src/main/java/org/komodo/metadata/internal/TeiidVdbImpl.java
@@ -66,10 +66,6 @@ public class TeiidVdbImpl implements TeiidVdb, Comparable<TeiidVdbImpl> {
         if (! (vdb instanceof VDBMetaData))
             throw new Exception(Messages.getString(Messages.MetadataServer.onlySupportingDynamicVdbs));
 
-        VDBMetaData vdbMeta = (VDBMetaData)vdb;
-        if (! vdbMeta.isXmlDeployment())
-            throw new Exception(Messages.getString(Messages.MetadataServer.onlySupportingDynamicVdbs));
-
         name = vdb.getName();
 
         // Autoboxing first if version is an int as defined in teiid 8

--- a/server/komodo-server/src/main/java/org/komodo/metadata/internal/TeiidVdbImpl.java
+++ b/server/komodo-server/src/main/java/org/komodo/metadata/internal/TeiidVdbImpl.java
@@ -17,7 +17,6 @@
  */
 package org.komodo.metadata.internal;
 
-import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -29,8 +28,8 @@ import org.komodo.metadata.runtime.TeiidVdb;
 import org.teiid.adminapi.Model;
 import org.teiid.adminapi.VDB;
 import org.teiid.adminapi.VDB.Status;
+import org.teiid.adminapi.VDBImport;
 import org.teiid.adminapi.impl.VDBMetaData;
-import org.teiid.adminapi.impl.VDBMetadataParser;
 import org.teiid.core.util.ArgCheck;
 
 public class TeiidVdbImpl implements TeiidVdb, Comparable<TeiidVdbImpl> {
@@ -59,7 +58,7 @@ public class TeiidVdbImpl implements TeiidVdb, Comparable<TeiidVdbImpl> {
 
     private Properties properties = new Properties();
 
-    private String vdbExport;
+	private VDB vdb;
 
     public TeiidVdbImpl(VDB vdb) throws Exception {
         ArgCheck.isNotNull(vdb, "vdb"); //$NON-NLS-1$
@@ -96,10 +95,8 @@ public class TeiidVdbImpl implements TeiidVdb, Comparable<TeiidVdbImpl> {
         for (String name : vdb.getProperties().stringPropertyNames()) {
             properties.setProperty(name, vdb.getPropertyValue(name));
         }
-
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        VDBMetadataParser.marshell((VDBMetaData)vdb, out);
-        vdbExport = new String(out.toByteArray());
+        
+        this.vdb = vdb;
     }
 
     /* (non-Javadoc)
@@ -221,7 +218,7 @@ public class TeiidVdbImpl implements TeiidVdb, Comparable<TeiidVdbImpl> {
     }
 
     @Override
-    public String export() throws Exception {
-        return vdbExport;
+    public List<? extends VDBImport> getImports() {
+    	return this.vdb.getVDBImports();
     }
 }

--- a/server/komodo-server/src/main/java/org/komodo/openshift/PublishConfiguration.java
+++ b/server/komodo-server/src/main/java/org/komodo/openshift/PublishConfiguration.java
@@ -24,18 +24,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.komodo.relational.vdb.Vdb;
 import org.komodo.rest.AuthHandlingFilter.OAuthCredentials;
 import org.komodo.spi.StringConstants;
-import org.komodo.spi.repository.UnitOfWork;
+import org.teiid.adminapi.impl.VDBMetaData;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
 
 public class PublishConfiguration implements StringConstants {
 
     private OAuthCredentials oauthCreds;
-    private UnitOfWork uow;
-    private Vdb vdb;
+    private VDBMetaData vdb;
     private boolean enableOdata;
     private String containerMemorySize;
     private String containerDiskSize;
@@ -55,11 +53,11 @@ public class PublishConfiguration implements StringConstants {
         return buildImageStream;
     }
 
-    public Vdb getVDB() {
+    public VDBMetaData getVDB() {
         return this.vdb;
     }
 
-    public void setVDB(Vdb vdb) {
+    public void setVDB(VDBMetaData vdb) {
         this.vdb = vdb;
     }
 
@@ -145,21 +143,6 @@ public class PublishConfiguration implements StringConstants {
 
     public void setOAuthCredentials(OAuthCredentials creds) {
         this.oauthCreds = creds;
-    }
-
-    public UnitOfWork getTransaction() {
-        return this.uow;
-    }
-
-    public void setTransaction(UnitOfWork uow) {
-        this.uow = uow;
-    }
-
-    public void dispose() {
-        if (this.uow == null)
-            return;
-
-        this.uow.rollback();
     }
 
     public HashMap<String, String> getBuildNodeSelector() {

--- a/server/komodo-server/src/main/java/org/komodo/rest/KomodoAutoConfiguration.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/KomodoAutoConfiguration.java
@@ -102,8 +102,8 @@ public class KomodoAutoConfiguration implements ApplicationListener<ContextRefre
             try {
 	        	// monitor to track connections from the syndesis
 				TeiidOpenShiftClient TOSClient = new TeiidOpenShiftClient(
-						kengine.getMetadataInstance(), kengine,
-						new EncryptionComponent(getTextEncryptor()), this.config);
+						kengine.getMetadataInstance(), new EncryptionComponent(getTextEncryptor()),
+						this.config);
 	        	SyndesisConnectionSynchronizer sync = new SyndesisConnectionSynchronizer(TOSClient);
 	        	SyndesisConnectionMonitor scm = new SyndesisConnectionMonitor(sync);
 	        	ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
@@ -137,8 +137,8 @@ public class KomodoAutoConfiguration implements ApplicationListener<ContextRefre
     @ConditionalOnMissingBean
     public TeiidOpenShiftClient openShiftClient(@Autowired KEngine kengine, @Autowired TextEncryptor enc) {
         try {
-            return new TeiidOpenShiftClient(kengine.getMetadataInstance(), kengine,
-                    new EncryptionComponent(enc), this.config);
+            return new TeiidOpenShiftClient(kengine.getMetadataInstance(), new EncryptionComponent(enc),
+                    this.config);
         } catch (KException e) {
             throw new RuntimeException(e);
         }

--- a/server/komodo-server/src/main/java/org/komodo/rest/KomodoService.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/KomodoService.java
@@ -316,7 +316,11 @@ public abstract class KomodoService implements V1Constants {
 
     protected Response createErrorResponseWithForbidden(List<MediaType> mediaTypes, Throwable ex,
                                                         RelationalMessages.Error errorType, Object... errorMsgInputs) {
-        return createErrorResponse(Status.FORBIDDEN, mediaTypes, ex, errorType, errorMsgInputs);
+        if (ex != null) {
+        	LOGGER.error(errorType.toString(), ex);
+        }
+    	
+    	return createErrorResponse(Status.FORBIDDEN, mediaTypes, ex, errorType, errorMsgInputs);
     }
 
     protected Response createErrorResponseWithForbidden(List<MediaType> mediaTypes,

--- a/server/komodo-server/src/main/java/org/komodo/rest/relational/dataservice/RestDataservice.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/relational/dataservice/RestDataservice.java
@@ -25,12 +25,9 @@ import java.util.Properties;
 import org.komodo.openshift.BuildStatus;
 import org.komodo.relational.WorkspaceManager;
 import org.komodo.relational.dataservice.Dataservice;
-import org.komodo.relational.model.Model;
-import org.komodo.relational.model.Model.Type;
 import org.komodo.relational.profile.Profile;
 import org.komodo.relational.profile.ViewDefinition;
 import org.komodo.relational.profile.ViewEditorState;
-import org.komodo.relational.vdb.Vdb;
 import org.komodo.rest.RestBasicEntity;
 import org.komodo.rest.RestLink;
 import org.komodo.rest.RestLink.LinkType;
@@ -108,7 +105,7 @@ public final class RestDataservice extends RestBasicEntity {
      * @param exportXml whether xml should be exported
      * @throws KException if error occurs
      */
-    public RestDataservice(URI baseUri, Dataservice dataService, boolean exportXml, Vdb serviceVdb) throws KException {
+    public RestDataservice(URI baseUri, Dataservice dataService, boolean exportXml, String vdbName) throws KException {
         super(baseUri);
         
         setId(dataService.getName());
@@ -120,13 +117,8 @@ public final class RestDataservice extends RestBasicEntity {
         URI parentUri = getUriBuilder().dataserviceParentUri(dataService);
         getUriBuilder().addSetting(settings, SettingNames.DATA_SERVICE_PARENT_PATH, parentUri);
 
-        if (serviceVdb != null) {
-            setServiceVdbName(serviceVdb.getVdbName( ));
-            setServiceVdbVersion(Integer.toString(serviceVdb.getVersion( )));
-            setHasChildren(true);
-        } else {
-        	setHasChildren(false);
-        }
+        setServiceVdbName(vdbName);
+        setHasChildren(true);
 
         // Initialize the published state to NOTFOUND
         setPublishedState(BuildStatus.Status.NOTFOUND.name());
@@ -271,36 +263,13 @@ public final class RestDataservice extends RestBasicEntity {
     }
     
     /**
-     * Get the service view name
-     * @param serviceVdb
-     * @return
-     * @throws KException
-     */
-    public static String getServiceViewModelName(Vdb serviceVdb) throws KException {
-        String viewModelName = null;
-        // Only ONE virtual model should exist in the dataservice vdb.
-        // The returned view model is the first virtual model found - or null if none found.
-        if( serviceVdb != null ) {
-            Model[] models = serviceVdb.getModels();
-            for(Model model : models) {
-                Model.Type modelType = model.getModelType();
-                if(modelType == Type.VIRTUAL) {
-                    viewModelName = model.getName();
-                    break;
-                }
-            }
-        }
-        return viewModelName;
-    }
-    
-    /**
      *  get the ViewDefinitionImpl names for the dataservice
      */
-    public static String[] getViewDefnNames(WorkspaceManager workspaceManager, Vdb serviceVdb) throws KException {
+    public static String[] getViewDefnNames(WorkspaceManager workspaceManager, String vdbName) throws KException {
         Profile userProfile = workspaceManager.getUserProfile();
         ViewEditorState[] editorStates = null;
         if (userProfile != null) {
-        	String svcVdbName = serviceVdb.getName().toLowerCase();
+        	String svcVdbName = vdbName.toLowerCase();
         	String pattern = svcVdbName + "*";
             editorStates = userProfile.getViewEditorStates(pattern);
         }

--- a/server/komodo-server/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
@@ -206,10 +206,9 @@ public final class KomodoDataserviceService extends KomodoService
     }
 
 	private RestDataservice createRestDataservice(final UriInfo uriInfo, KomodoProperties properties, final Dataservice dataService) throws KException {
-		Vdb serviceVdb = findVdb(dataService.getServiceVdbName());
-		RestDataservice entity = new RestDataservice(uriInfo.getBaseUri(), dataService, false, serviceVdb);
-		entity.setServiceViewModel(RestDataservice.getServiceViewModelName(serviceVdb));
-        entity.setViewDefinitionNames(RestDataservice.getViewDefnNames(getWorkspaceManager(), serviceVdb));
+		RestDataservice entity = new RestDataservice(uriInfo.getBaseUri(), dataService, false, dataService.getServiceVdbName());
+		entity.setServiceViewModel(SERVICE_VDB_VIEW_MODEL);
+        entity.setViewDefinitionNames(RestDataservice.getViewDefnNames(getWorkspaceManager(), dataService.getServiceVdbName()));
 		// Set published status of dataservice
 		BuildStatus status = this.openshiftClient.getVirtualizationStatus(dataService.getServiceVdbName());
 		entity.setPublishedState(status.status().name());
@@ -376,7 +375,7 @@ public final class KomodoDataserviceService extends KomodoService
         // Transfers the properties from the rest object to the created komodo service.
         setProperties(dataservice, restDataservice);
 
-        String serviceVdbName = dataserviceName.toLowerCase() + SERVICE_VDB_SUFFIX;
+        String serviceVdbName = dataservice.getServiceVdbName();
         WorkspaceManager wkspMgr = getWorkspaceManager();
 
         // Find the service VDB definition for this Dataservice. If one exists already,

--- a/server/komodo-server/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
@@ -48,10 +48,7 @@ import org.komodo.openshift.ProtocolType;
 import org.komodo.openshift.TeiidOpenShiftClient;
 import org.komodo.relational.WorkspaceManager;
 import org.komodo.relational.dataservice.Dataservice;
-import org.komodo.relational.model.Model;
-import org.komodo.relational.model.Model.Type;
 import org.komodo.relational.profile.ViewEditorState;
-import org.komodo.relational.vdb.Vdb;
 import org.komodo.rest.KomodoRestException;
 import org.komodo.rest.KomodoRestV1Application.V1Constants;
 import org.komodo.rest.KomodoService;
@@ -375,22 +372,6 @@ public final class KomodoDataserviceService extends KomodoService
         // Transfers the properties from the rest object to the created komodo service.
         setProperties(dataservice, restDataservice);
 
-        String serviceVdbName = dataservice.getServiceVdbName();
-        WorkspaceManager wkspMgr = getWorkspaceManager();
-
-        // Find the service VDB definition for this Dataservice. If one exists already,
-        // it is replaced.
-        Vdb svcVdbObj = wkspMgr.findVdb(serviceVdbName);
-        if (svcVdbObj != null) {
-            wkspMgr.deleteVdb(svcVdbObj);
-        }
-
-        Vdb serviceVdb = wkspMgr.createVdb(serviceVdbName);
-
-        // Add to the ServiceVdb a virtual model for the View
-        Model viewModel = serviceVdb.addModel(SERVICE_VDB_VIEW_MODEL);
-        viewModel.setModelType(Type.VIRTUAL);
-
         KomodoStatusObject kso = new KomodoStatusObject("Create Status"); //$NON-NLS-1$
         kso.addAttribute(dataserviceName, "Successfully created"); //$NON-NLS-1$
         
@@ -456,13 +437,7 @@ public final class KomodoDataserviceService extends KomodoService
                         RelationalMessages.Error.DATASERVICE_SERVICE_SERVICE_DNE);
             }
 
-            // Delete the Dataservice serviceVDB if found
             String vdbName = dataservice.getServiceVdbName();
-            Vdb serviceVdb = findVdb(vdbName);
-
-            if (serviceVdb != null) {
-                wkspMgr.deleteVdb(serviceVdb);
-            }
 
             // Delete the Dataservice
             wkspMgr.deleteDataservice(dataservice);
@@ -609,15 +584,18 @@ public final class KomodoDataserviceService extends KomodoService
             if (dataservice == null)
                 return commitNoDataserviceFound(uow, mediaTypes, dataserviceName);
 
-            String vdbName = dataservice.getServiceVdbName();
-            Vdb serviceVdb = findVdb(vdbName);
+            //String vdbName = dataservice.getServiceVdbName();
 
             // Get all of the editor states from the user profile
             // They are stored under ids of form "serviceVdbName.viewName"
-            final String viewEditorIdPrefix = KomodoService.getViewEditorStateIdPrefix(vdbName) + "*"; //$NON-NLS-1$
+            /*final String viewEditorIdPrefix = KomodoService.getViewEditorStateIdPrefix(vdbName) + "*"; //$NON-NLS-1$
             final ViewEditorState[] editorStates = getViewEditorStates(viewEditorIdPrefix);
 
-            new ServiceVdbGenerator(getWorkspaceManager()).refreshServiceVdb(serviceVdb, editorStates);
+            VDBMetaData vdb = new ServiceVdbGenerator(getWorkspaceManager()).refreshServiceVdb(serviceVdb, editorStates);
+            
+            TODO: should we generate and deploy a virtualization specific preview vdb?
+            
+            */
 
             KomodoStatusObject kso = new KomodoStatusObject("Refresh Status"); //$NON-NLS-1$
             kso.addAttribute(dataserviceName, "View Successfully refreshed"); //$NON-NLS-1$

--- a/server/komodo-server/src/main/java/org/komodo/rest/service/KomodoUtilService.java
+++ b/server/komodo-server/src/main/java/org/komodo/rest/service/KomodoUtilService.java
@@ -88,7 +88,9 @@ import io.swagger.annotations.ApiResponses;
 @Api( tags = {V1Constants.SERVICE_SEGMENT} )
 public final class KomodoUtilService extends KomodoService {
 
-    private static final String REPO_VDB_TOTAL = "Repository Vdb Total"; //$NON-NLS-1$
+    private static final String PREVIEW_VDB = "PreviewVdb";
+
+	private static final String REPO_VDB_TOTAL = "Repository Vdb Total"; //$NON-NLS-1$
 
     public static final String APP_NAME = "App Name"; //$NON-NLS-1$
 
@@ -518,11 +520,11 @@ public final class KomodoUtilService extends KomodoService {
 	            ModelMetaData m = new ModelMetaData();
 	            m.setName("m"); //$NON-NLS-1$
 	        	
-				MetadataFactory mf = new MetadataFactory("PreviewVdb", 1,SystemMetadata.getInstance().getRuntimeTypeMap(),m);
+				MetadataFactory mf = new MetadataFactory(PREVIEW_VDB, 1,SystemMetadata.getInstance().getRuntimeTypeMap(),m);
 	        	parser.parseDDL(mf, restViewDefinition.getDdl());
 	        	
 				VDBMetaData vdb = (VDBMetaData) this.kengine.getMetadataInstance().getAdmin()
-						.getVDB("PreviewVdb", "1");
+						.getVDB(PREVIEW_VDB, "1");
 				TransformationMetadata qmi = vdb.getAttachment(TransformationMetadata.class);
 	        	
 				CompositeMetadataStore store = qmi.getMetadataStore();

--- a/server/komodo-server/src/test/java/org/komodo/rest/relational/RestDataserviceTest.java
+++ b/server/komodo-server/src/test/java/org/komodo/rest/relational/RestDataserviceTest.java
@@ -30,7 +30,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.komodo.openshift.BuildStatus;
 import org.komodo.relational.dataservice.Dataservice;
-import org.komodo.relational.vdb.Vdb;
 import org.komodo.rest.relational.dataservice.RestDataservice;
 import org.mockito.Mockito;
 
@@ -70,15 +69,11 @@ public final class RestDataserviceTest {
 
     @Before
     public void init() throws Exception {
-        Vdb serviceVdb = Mockito.mock(Vdb.class);
-        Mockito.when(serviceVdb.getName()).thenReturn("ServiceVdb");
-        Mockito.when(serviceVdb.getVersion()).thenReturn(1);
-
         Dataservice theDataservice = Mockito.mock(Dataservice.class);
         Mockito.when(theDataservice.getName()).thenReturn(DATASERVICE_NAME);
         Mockito.when(theDataservice.getServiceVdbName()).thenReturn("ServiceVdb");
 
-        this.dataservice = new RestDataservice(BASE_URI, theDataservice, false, serviceVdb);
+        this.dataservice = new RestDataservice(BASE_URI, theDataservice, false, "ServiceVdb");
         this.dataservice.setId(DATASERVICE_NAME);
         this.dataservice.setDescription(DESCRIPTION);
         this.dataservice.setServiceVdbName(SERVICE_VDB_NAME);

--- a/server/komodo-server/src/test/java/org/komodo/rest/relational/json/DataserviceSerializerTest.java
+++ b/server/komodo-server/src/test/java/org/komodo/rest/relational/json/DataserviceSerializerTest.java
@@ -24,7 +24,6 @@ import java.net.URLDecoder;
 import org.junit.Before;
 import org.junit.Test;
 import org.komodo.relational.dataservice.Dataservice;
-import org.komodo.relational.vdb.Vdb;
 import org.komodo.rest.relational.dataservice.RestDataservice;
 import org.mockito.Mockito;
 
@@ -38,7 +37,7 @@ public final class DataserviceSerializerTest extends AbstractSerializerTest  {
         "  \"keng__id\": \"" + DATASERVICE_NAME + "\"," + NEW_LINE +
         "  \"keng__kType\": \"Dataservice\"," + NEW_LINE +
         "  \"tko__description\": \"my description\"," + NEW_LINE +
-        "  \"serviceVdbVersion\": \"1\"," + NEW_LINE +
+        "  \"serviceVdbName\": \"ServiceVdb\"," + NEW_LINE +
         "  \"keng__hasChildren\": true," + NEW_LINE +
         "  \"publishedState\": \"NOTFOUND\"," + NEW_LINE +
         "  \"keng___links\": [" + NEW_LINE +
@@ -61,14 +60,10 @@ public final class DataserviceSerializerTest extends AbstractSerializerTest  {
 
     @Before
     public void init() throws Exception {
-        Vdb serviceVdb = Mockito.mock(Vdb.class);
-        Mockito.when(serviceVdb.getName()).thenReturn("ServiceVdb");
-        Mockito.when(serviceVdb.getVersion()).thenReturn(1);
-
         Dataservice theService = Mockito.mock(Dataservice.class);
         Mockito.when(theService.getName()).thenReturn(DATASERVICE_NAME);
 
-        this.dataservice = new RestDataservice(MY_BASE_URI, theService, false, serviceVdb);
+        this.dataservice = new RestDataservice(MY_BASE_URI, theService, false, "ServiceVdb");
         this.dataservice.setDescription(DESCRIPTION);
     }
 

--- a/server/komodo-server/src/test/java/org/komodo/rest/service/KomodoMetadataServiceTest.java
+++ b/server/komodo-server/src/test/java/org/komodo/rest/service/KomodoMetadataServiceTest.java
@@ -20,14 +20,13 @@ package org.komodo.rest.service;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.ByteArrayOutputStream;
 import java.util.Properties;
 
 import org.junit.Test;
+import org.komodo.metadata.internal.DefaultMetadataInstance;
 import org.komodo.metadata.internal.TeiidDataSourceImpl;
 import org.komodo.metadata.runtime.TeiidDataSource;
 import org.teiid.adminapi.impl.VDBMetaData;
-import org.teiid.adminapi.impl.VDBMetadataParser;
 
 @SuppressWarnings({ "javadoc", "nls" })
 public class KomodoMetadataServiceTest {
@@ -39,10 +38,9 @@ public class KomodoMetadataServiceTest {
 		properties.setProperty(TeiidDataSource.DATASOURCE_DRIVERNAME, "type");
 		TeiidDataSourceImpl tds = new TeiidDataSourceImpl("source", properties);
 		VDBMetaData vdb = KomodoMetadataService.generateSourceVdb(tds, "vdb");
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		VDBMetadataParser.marshell(vdb, baos);
 		
-		String s = new String(baos.toByteArray(), "UTF-8");
+		
+		String s = new String(DefaultMetadataInstance.toBytes(vdb).toByteArray(), "UTF-8");
 		assertEquals(
 				"<?xml version=\"1.0\" ?><vdb name=\"vdb\" version=\"1\"><description>Vdb for source Data Source:	source\n"
 						+ "Type: 		type</description><connection-type>BY_VERSION</connection-type>"

--- a/server/komodo-server/src/test/java/org/komodo/rest/service/KomodoMetadataServiceTest.java
+++ b/server/komodo-server/src/test/java/org/komodo/rest/service/KomodoMetadataServiceTest.java
@@ -20,11 +20,14 @@ package org.komodo.rest.service;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.ByteArrayOutputStream;
 import java.util.Properties;
 
 import org.junit.Test;
 import org.komodo.metadata.internal.TeiidDataSourceImpl;
 import org.komodo.metadata.runtime.TeiidDataSource;
+import org.teiid.adminapi.impl.VDBMetaData;
+import org.teiid.adminapi.impl.VDBMetadataParser;
 
 @SuppressWarnings({ "javadoc", "nls" })
 public class KomodoMetadataServiceTest {
@@ -35,9 +38,11 @@ public class KomodoMetadataServiceTest {
 		properties.setProperty(TeiidDataSource.DATASOURCE_JNDINAME, "something");
 		properties.setProperty(TeiidDataSource.DATASOURCE_DRIVERNAME, "type");
 		TeiidDataSourceImpl tds = new TeiidDataSourceImpl("source", properties);
-		byte[] bytes = KomodoMetadataService.generateSourceVdb(tds, "vdb");
+		VDBMetaData vdb = KomodoMetadataService.generateSourceVdb(tds, "vdb");
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		VDBMetadataParser.marshell(vdb, baos);
 		
-		String s = new String(bytes, "UTF-8");
+		String s = new String(baos.toByteArray(), "UTF-8");
 		assertEquals(
 				"<?xml version=\"1.0\" ?><vdb name=\"vdb\" version=\"1\"><description>Vdb for source Data Source:	source\n"
 						+ "Type: 		type</description><connection-type>BY_VERSION</connection-type>"

--- a/server/komodo-spi/src/main/java/org/komodo/metadata/MetadataInstance.java
+++ b/server/komodo-spi/src/main/java/org/komodo/metadata/MetadataInstance.java
@@ -17,7 +17,6 @@
  */
 package org.komodo.metadata;
 
-import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
 
@@ -25,11 +24,11 @@ import org.komodo.metadata.query.QSResult;
 import org.komodo.metadata.runtime.TeiidDataSource;
 import org.komodo.metadata.runtime.TeiidVdb;
 import org.komodo.relational.DeployStatus;
-import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.StringConstants;
 import org.teiid.adminapi.Admin;
 import org.teiid.adminapi.AdminException;
+import org.teiid.adminapi.impl.VDBMetaData;
 
 public interface MetadataInstance extends StringConstants {
 
@@ -234,15 +233,6 @@ public interface MetadataInstance extends StringConstants {
     String getSchema(String vdbName, String version, String modelName) throws KException;
 
     /**
-     * Deploy a dynamic vdb
-     *
-     * @param vdbDeploymentName
-     * @param stream
-     * @throws KException 
-     */
-    void deployDynamicVdb(String vdbName, String vdbDeploymentName, InputStream stream) throws KException;
-
-    /**
      * Undeploy the dynamic vdb with the given name
      * @param name
      * @throws KException 
@@ -283,5 +273,5 @@ public interface MetadataInstance extends StringConstants {
      * @param vdb
      * @return the deployment status of the vdb
      */
-	DeployStatus deploy(Vdb vdb);
+	DeployStatus deploy(VDBMetaData vdb) throws KException;
 }

--- a/server/komodo-spi/src/main/java/org/komodo/metadata/runtime/TeiidVdb.java
+++ b/server/komodo-spi/src/main/java/org/komodo/metadata/runtime/TeiidVdb.java
@@ -21,6 +21,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 
+import org.teiid.adminapi.VDBImport;
+
 /**
  *
  */
@@ -108,11 +110,6 @@ public interface TeiidVdb {
      */
     Properties getProperties( );
     
-    /**
-     * 
-     * @return xml string of the vdb
-     * @throws Exception 
-     */
-    String export( ) throws Exception;
+	List<? extends VDBImport> getImports();
 
 }

--- a/server/komodo-spi/src/main/java/org/komodo/spi/KEngine.java
+++ b/server/komodo-spi/src/main/java/org/komodo/spi/KEngine.java
@@ -62,10 +62,4 @@ public interface KEngine {
      */
 	UnitOfWork createTransaction(String userName, String name, boolean rollbackOnly, String repoUser) throws KException;
 	
-	/**
-	 * Associates the given transaction with the current thread.
-	 * @param uow
-	 */
-	void associateTransaction(UnitOfWork uow);
-
 }


### PR DESCRIPTION
This removes the modeshape storage of the service vdb - leaving only the schema vdbs.  For now the refresh views service method is not doing anything, rather the service vdb is built on demand with publishing from the view editor states.  This of course could be refined such that the refresh method creates a deployed version of a virtualization specific vdb which could be reused if it exists on a publishing call.